### PR TITLE
Add layered Hyprland home configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Hyprland and Waybar are managed as a session UX substrate rather than loose rice
 Ownership model:
 
 - Home Manager owns generated base files under `~/.config/hypr` and `~/.config/waybar`.
-- `~/.config/hypr/adopted.d/machine.conf` is selected by `dotfiles.hypr.adoptedProfile`.
+- `dotfiles.hypr.adoptedProfile` selects machine profile content embedded into generated `~/.config/hypr/hyprland.conf`.
+- `~/.config/hypr/adopted.d/machine.conf` is retained for adopted/archive visibility but is not sourced during normal Hyprland load.
 - `~/.config/hypr/local.conf` is writable machine-local state and should not be auto-promoted.
 - `~/.config/hypr/custom.d/*.conf` is the promotion staging area for user-authored Hyprland fragments.
 - `~/.config/waybar/custom.css` is the local stylesheet hook for Waybar experiments.

--- a/modules/home/hypr.nix
+++ b/modules/home/hypr.nix
@@ -6,6 +6,8 @@ let
     empty = ../../files/home/.config/hypr/adopted.d/empty.conf;
   };
 
+  managedHyprConfig = builtins.readFile adoptedProfiles.${config.dotfiles.hypr.adoptedProfile};
+
   managedScripts = [
     "dub-browser"
     "dub-clipboard"
@@ -34,26 +36,22 @@ in
   options.dotfiles.hypr.adoptedProfile = lib.mkOption {
     type = lib.types.enum (builtins.attrNames adoptedProfiles);
     default = "empty";
-    description = "Machine-specific Hyprland adopted fragment to install as adopted.d/machine.conf.";
+    description = "Machine-specific Hyprland profile content to embed into the managed generated config.";
   };
 
   config = lib.mkIf config.dotfiles.profiles.workstation.enable {
     xdg.configFile."hypr/hyprland.conf".text = ''
       # GENERATED FILE — DO NOT EDIT DIRECTLY
-      # Source of truth: ryjen/dotfiles Home Manager modules
+      # source-of-truth: ryjen/dotfiles
+      # local-layer: ~/.config/hypr/local.conf
+      # custom-layer: ~/.config/hypr/custom.d/*.conf
+      # adopted-layer: ~/.config/hypr/adopted.d/*
       #
-      # Local machine-specific overrides:
-      #   ~/.config/hypr/local.conf
-      #
-      # Promotion candidates:
-      #   ~/.config/hypr/custom.d/*.conf
-      #
-      # Adopted machine profile:
-      #   ~/.config/hypr/adopted.d/machine.conf
-      #
-      # configctl should never auto-promote local.conf.
-      # configctl may reconcile and promote custom.d fragments.
-      source = ~/.config/hypr/adopted.d/*.conf
+      # adopted.d is retained for adopted/archive fragments and is not sourced
+      # during normal load.
+
+      ${managedHyprConfig}
+
       source = ~/.config/hypr/local.conf
       source = ~/.config/hypr/custom.d/*.conf
     '';
@@ -78,7 +76,7 @@ in
       # Ownership:
       # - machine-specific
       # - writable by the user
-      # - never automatically promoted by configctl
+      # - never automatically promoted
       #
       # Examples:
       # monitor=,preferred,auto,1


### PR DESCRIPTION
## Summary

- adds the first concrete layered home configuration implementation for Hyprland
- keeps managed Hyprland config generated by dotfiles/Home Manager
- embeds the selected managed profile content into generated `hyprland.conf`
- keeps local and custom layers active for machine-specific and user-authored fragments
- keeps adopted fragments out of the active load path

## Safety

- no automatic promotion
- no reconciliation mutation
- no changes to adopted fragments
- local/custom files remain user-owned
- existing selected profile behavior is preserved by embedding profile content into the managed generated config

## Validation

- [x] reviewed diff against `main`
- [ ] git diff --check
- [ ] nix flake check
- [ ] manual inspection of generated Hypr config

Validation requiring a local checkout/Nix runtime was not run through the GitHub connector.