### PR TITLE
[codex] Fix Neovim runtime startup errors

### DIFF
--- a/files/home/.config/nvim/lua/plugins.lua
+++ b/files/home/.config/nvim/lua/plugins.lua
@@ -79,13 +79,9 @@ local function init()
 		},
 	})
 
-	-- Post-install/update hook with neovim command.
+	-- Syntax tree support.
 	use({
 		"nvim-treesitter/nvim-treesitter",
-		requires = {
-			"nvim-treesitter/nvim-treesitter-refactor",
-			"RRethy/nvim-treesitter-textsubjects",
-		},
 		run = ":TSUpdate",
 	})
 

--- a/files/home/.config/nvim/plugin/lsp.lua
+++ b/files/home/.config/nvim/plugin/lsp.lua
@@ -122,29 +122,30 @@ if cmp_nvim_lsp then
 	capabilities = cmp_nvim_lsp.default_capabilities(capabilities)
 end
 
-local lspconfig = optional_require("lspconfig")
-if lspconfig then
-	-- Server executables are installed by Home Manager in modules/home/neovim.nix.
-	local servers = {
-		lua_ls = {},
-		nil_ls = {},
-		pyright = {},
-	}
+local function configure_lsp(server, config)
+	config = vim.tbl_extend("force", {
+		on_attach = on_attach,
+		capabilities = capabilities,
+	}, config or {})
 
-	if lspconfig.ts_ls then
-		servers.ts_ls = {}
-	elseif lspconfig.tsserver then
-		servers.tsserver = {}
+	if vim.lsp.config then
+		vim.lsp.config(server, config)
+		vim.lsp.enable(server)
+		return
 	end
 
-	for server, config in pairs(servers) do
-		if lspconfig[server] then
-			config.on_attach = on_attach
-			config.capabilities = capabilities
-			lspconfig[server].setup(config)
-		end
+	-- Compatibility fallback for older Neovim/lspconfig combinations.
+	local lspconfig = optional_require("lspconfig")
+	if lspconfig and lspconfig[server] then
+		lspconfig[server].setup(config)
 	end
 end
+
+-- Server executables are installed by Home Manager in modules/home/neovim.nix.
+configure_lsp("lua_ls", {})
+configure_lsp("nil_ls", {})
+configure_lsp("pyright", {})
+configure_lsp("ts_ls", {})
 
 local null_ls = optional_require("null-ls")
 if null_ls then

--- a/files/home/.config/nvim/plugin/treesitter.lua
+++ b/files/home/.config/nvim/plugin/treesitter.lua
@@ -1,28 +1,20 @@
-local ts_configs = require 'nvim-treesitter.configs'
-ts_configs.setup {
-  ensure_installed = 'all',
-  highlight = { enable = true, use_languagetree = true },
-  indent = { enable = false },
-  incremental_selection = {
-    enable = true,
-    keymaps = {
-      init_selection = 'gnn',
-      node_incremental = 'grn',
-      scope_incremental = 'grc',
-      node_decremental = 'grm',
-    },
-  },
-  refactor = {
-    smart_rename = { enable = true, keymaps = { smart_rename = 'grr' } },
-    highlight_definitions = { enable = true },
-    -- highlight_current_scope = { enable = true }
-  },
-  textsubjects = {
-    enable = true,
-    keymaps = {
-      ['.'] = 'textsubjects-smart',
-      [';'] = 'textsubjects-container-outer',
-    },
-  },
-  endwise = { enable = true },
-}
+local ok, ts_configs = pcall(require, "nvim-treesitter.configs")
+if not ok then
+	vim.notify("nvim-treesitter is unavailable; skipping Treesitter setup", vim.log.levels.WARN)
+	return
+end
+
+ts_configs.setup({
+	ensure_installed = "all",
+	highlight = { enable = true, use_languagetree = true },
+	indent = { enable = false },
+	incremental_selection = {
+		enable = true,
+		keymaps = {
+			init_selection = "gnn",
+			node_incremental = "grn",
+			scope_incremental = "grc",
+			node_decremental = "grm",
+		},
+	},
+})


### PR DESCRIPTION
## Summary

Follow-up to #25 for the runtime errors seen after activation.

### Changed

- Switches LSP setup to Neovim 0.11's native `vim.lsp.config` / `vim.lsp.enable` API.
- Keeps a guarded `lspconfig.setup` fallback for older Neovim versions.
- Guards `plugin/treesitter.lua` so missing or partially-installed `nvim-treesitter` no longer aborts startup.
- Removes `nvim-treesitter-refactor` and `nvim-treesitter-textsubjects` from the active packer manifest to avoid stale add-on startup failures.
- Simplifies Treesitter config to core highlighting and incremental selection only.

## Why

Current startup shows:

- `require('lspconfig')` framework deprecation warning from `plugin/lsp.lua`
- hard failure from `plugin/treesitter.lua` when `nvim-treesitter.configs` is unavailable
- hard failure from stale `nvim-treesitter-refactor` under `site/pack/packer/start`

The config should tolerate a fresh or partially-cleaned packer state and should not rely on the deprecated lspconfig framework path on Neovim 0.11+.

## Manual cleanup after merge

Run one of these locally to remove stale packer-installed add-ons that are no longer in the manifest:

```vim
:PackerSync
:PackerClean
```

or, if the packer tree is badly stale:

```bash
rm -rf ~/.local/share/nvim/site/pack/packer
nvim +PackerSync
```

## Validation

Not run locally through this connector. Recommended checks:

```bash
nix flake check --show-trace
nix run .#verify-neovim-config
nvim --headless +qa
```