### PR TITLE
[codex] Migrate Neovim plugin management to lazy.nvim

### DIFF
--- a/files/home/.config/nvim/init.lua
+++ b/files/home/.config/nvim/init.lua
@@ -1,7 +1,6 @@
 vim.loader.enable()
 
 local g = vim.g
-local cmd = vim.cmd
 local fn = vim.fn
 
 -- Disable some built-in plugins we don't want.
@@ -51,15 +50,8 @@ end
 -- Sensible defaults
 require("settings")
 
--- Commands
-cmd([[command! PackerInstall packadd packer.nvim | lua require('plugins').install()]])
-cmd([[command! PackerUpdate packadd packer.nvim | lua require('plugins').update()]])
-cmd([[command! PackerSync packadd packer.nvim | lua require('plugins').sync()]])
-cmd([[command! PackerClean packadd packer.nvim | lua require('plugins').clean()]])
-cmd([[command! PackerCompile packadd packer.nvim | lua require('plugins').compile()]])
-
--- Auto compile when there are changes in plugins.lua
-cmd("autocmd BufWritePost plugins.lua PackerCompile")
+-- Plugin manager and plugin specs
+require("plugins")
 
 -- Key mappings
 require("keymappings")

--- a/files/home/.config/nvim/lua/plugins.lua
+++ b/files/home/.config/nvim/lua/plugins.lua
@@ -1,99 +1,97 @@
-local packer = nil
-local function init()
-	if packer == nil then
-		packer = require("packer")
-		packer.init({ disable_commands = true })
-	end
-
-	local use = packer.use
-	packer.reset()
-
-	-- Packer can manage itself.
-	use("wbthomason/packer.nvim")
-
-	-- Language server protocol. Language server binaries are installed by Home Manager.
-	use({
-		"neovim/nvim-lspconfig",
-		"folke/trouble.nvim",
-		"ray-x/lsp_signature.nvim",
-		"kosayoda/nvim-lightbulb",
+local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
+if not vim.loop.fs_stat(lazypath) then
+	vim.fn.system({
+		"git",
+		"clone",
+		"--filter=blob:none",
+		"https://github.com/folke/lazy.nvim.git",
+		"--branch=stable",
+		lazypath,
 	})
-	use({ "nvimtools/none-ls.nvim", requires = { "nvim-lua/plenary.nvim" } })
+end
+vim.opt.rtp:prepend(lazypath)
 
-	use("fidian/hexmode")
+require("lazy").setup({
+	-- Language server protocol. Language server binaries are installed by Home Manager.
+	{
+		"neovim/nvim-lspconfig",
+		dependencies = {
+			"folke/trouble.nvim",
+			"ray-x/lsp_signature.nvim",
+			"kosayoda/nvim-lightbulb",
+		},
+	},
+	{ "nvimtools/none-ls.nvim", dependencies = { "nvim-lua/plenary.nvim" } },
+
+	"fidian/hexmode",
 
 	-- Completion.
-	use({
+	{
 		"hrsh7th/nvim-cmp",
-		requires = {
+		event = "InsertEnter",
+		dependencies = {
 			"L3MON4D3/LuaSnip",
-			{ "hrsh7th/cmp-buffer", after = "nvim-cmp" },
-			{ "hrsh7th/cmp-nvim-lsp", after = "nvim-cmp" },
-			{ "hrsh7th/cmp-nvim-lsp-signature-help", after = "nvim-cmp" },
-			{ "hrsh7th/cmp-path", after = "nvim-cmp" },
-			{ "hrsh7th/cmp-nvim-lua", after = "nvim-cmp" },
-			{ "saadparwaiz1/cmp_luasnip", after = "nvim-cmp" },
+			"hrsh7th/cmp-buffer",
+			"hrsh7th/cmp-nvim-lsp",
+			"hrsh7th/cmp-nvim-lsp-signature-help",
+			"hrsh7th/cmp-path",
+			"hrsh7th/cmp-nvim-lua",
+			"saadparwaiz1/cmp_luasnip",
 			"lukas-reineke/cmp-under-comparator",
-			{ "hrsh7th/cmp-nvim-lsp-document-symbol", after = "nvim-cmp" },
+			"hrsh7th/cmp-nvim-lsp-document-symbol",
 		},
-		config = [[require('config.cmp')]],
-		event = "InsertEnter *",
-	})
+		config = function()
+			require("config.cmp")
+		end,
+	},
 
 	-- Themes.
-	use("altercation/vim-colors-solarized")
+	"altercation/vim-colors-solarized",
 
 	-- Bufferline.
-	use({
+	{
 		"akinsho/nvim-bufferline.lua",
-		requires = "nvim-tree/nvim-web-devicons",
-		config = [[require('config.bufferline')]],
 		event = "User ActuallyEditing",
-	})
+		dependencies = { "nvim-tree/nvim-web-devicons" },
+		config = function()
+			require("config.bufferline")
+		end,
+	},
 
 	-- Fuzzy finder.
-	use({
-		{
-			"nvim-telescope/telescope.nvim",
-			requires = {
-				"nvim-lua/plenary.nvim",
-				"nvim-telescope/telescope-ui-select.nvim",
-				{
-					"nvim-telescope/telescope-frecency.nvim",
-					requires = "kkharji/sqlite.lua",
-				},
-				{
-					"nvim-telescope/telescope-fzf-native.nvim",
-					run = "make",
-				},
+	{
+		"nvim-telescope/telescope.nvim",
+		cmd = "Telescope",
+		dependencies = {
+			"nvim-lua/plenary.nvim",
+			"nvim-telescope/telescope-ui-select.nvim",
+			{
+				"nvim-telescope/telescope-frecency.nvim",
+				dependencies = { "kkharji/sqlite.lua" },
 			},
-			wants = {
-				"plenary.nvim",
-				"telescope-frecency.nvim",
-				"telescope-fzf-native.nvim",
+			{
+				"nvim-telescope/telescope-fzf-native.nvim",
+				build = "make",
 			},
-			setup = [[require('config.telescope_setup')]],
-			config = [[require('config.telescope')]],
-			cmd = "Telescope",
-			module = "telescope",
 		},
-	})
+		init = function()
+			require("config.telescope_setup")
+		end,
+		config = function()
+			require("config.telescope")
+		end,
+	},
 
 	-- Syntax tree support.
-	use({
+	{
 		"nvim-treesitter/nvim-treesitter",
-		run = ":TSUpdate",
-	})
+		build = ":TSUpdate",
+	},
 
 	-- Default keyboard layout.
-	use("jooize/vim-colemak")
-end
-
-local plugins = setmetatable({}, {
-	__index = function(_, key)
-		init()
-		return packer[key]
-	end,
+	"jooize/vim-colemak",
+}, {
+	checker = { enabled = false },
+	install = { missing = true },
+	change_detection = { notify = false },
 })
-
-return plugins

--- a/files/home/.config/nvim/lua/plugins.lua
+++ b/files/home/.config/nvim/lua/plugins.lua
@@ -19,6 +19,7 @@ require("lazy").setup({
 			"folke/trouble.nvim",
 			"ray-x/lsp_signature.nvim",
 			"kosayoda/nvim-lightbulb",
+			"hrsh7th/cmp-nvim-lsp",
 		},
 	},
 	{ "nvimtools/none-ls.nvim", dependencies = { "nvim-lua/plenary.nvim" } },

--- a/flake.nix
+++ b/flake.nix
@@ -89,6 +89,7 @@
         name = "verify-neovim-config";
         runtimeInputs = [
           pkgs.coreutils
+          pkgs.git
           pkgs.neovim
         ];
         text = ''


### PR DESCRIPTION
## Summary

Migrates the Neovim plugin manager from `packer.nvim` to `lazy.nvim`.

### Changed

- Replaces Packer command/bootstrap wiring in `init.lua` with `require("plugins")`.
- Rewrites `lua/plugins.lua` as a lazy.nvim bootstrap and plugin spec list.
- Preserves the current plugin set and config modules as much as possible.
- Keeps language server binaries owned by Home Manager/Nix.
- Keeps Neovim 0.11 native LSP configuration from the previous runtime-fix PR.
- Adds `git` to the `verify-neovim-config` runtime so the lazy.nvim bootstrap can clone itself during isolated smoke tests.

## Why

`packer.nvim` is older and less maintained for modern Neovim setups. `lazy.nvim` gives clearer plugin specs, better lazy-loading semantics, lockfile support, and cleaner startup behavior.

## Validation

Not run locally through this connector. Recommended checks:

```bash
nix flake check --show-trace
nix run .#verify-neovim-config
nvim --headless +qa
```

## Local cleanup after merge

Remove stale packer state so old Packer-managed plugins do not keep loading:

```bash
rm -rf ~/.local/share/nvim/site/pack/packer
rm -rf ~/.local/share/nvim/lazy
nvim --headless '+Lazy! sync' +qa
```

Then open Neovim normally and run:

```vim
:Lazy
```

## Notes

This intentionally keeps plugin behavior mostly unchanged. Follow-up work can split specs into `lua/plugins/*.lua`, add a committed `lazy-lock.json`, or tune lazy-loading after the migration is stable.