### PR TITLE
Ensure Nerd Font symbols are installed

### DIFF
--- a/modules/nixos/fonts.nix
+++ b/modules/nixos/fonts.nix
@@ -5,6 +5,7 @@
 {
   fonts.packages = with pkgs; [
     nerd-fonts.jetbrains-mono
+    nerd-fonts.symbols-only
     dejavu_fonts
     inter
   ];
@@ -13,7 +14,11 @@
     enable = true;
     antialias = true;
     defaultFonts = {
-      monospace = [ "JetBrainsMono Nerd Font" ];
+      monospace = [
+        "JetBrainsMono Nerd Font Mono"
+        "JetBrainsMono Nerd Font"
+        "Symbols Nerd Font Mono"
+      ];
       sansSerif = [ "Inter" ];
       serif = [ "DejaVu Serif" ];
     };


### PR DESCRIPTION
## Summary

- Install `nerd-fonts.symbols-only` alongside JetBrains Mono Nerd Font.
- Prefer the exact monospaced JetBrainsMono Nerd Font family in fontconfig defaults.
- Keep `Symbols Nerd Font Mono` available as a monospace fallback for icon glyphs used by Waybar.

## Notes

Waybar already references `JetBrainsMono Nerd Font` and `Symbols Nerd Font Mono`, and Alacritty already uses `JetBrainsMono Nerd Font Mono`. This PR makes the installed font set match those configured family names more explicitly.

## Validation

Not run locally from this environment.