### PR TITLE
[codex] Add Variety wallpaper downloader

### DIFF
--- a/modules/home/hypr.nix
+++ b/modules/home/hypr.nix
@@ -135,16 +135,16 @@ in
       chmod 600 "$variety_config"
 
       tmp="$(${pkgs.coreutils}/bin/mktemp)"
-      ${pkgs.gnugrep}/bin/grep -Ev '^(download_folder|fetched_folder|favorites_folder|copyto_folder|wallpaper_auto_rotate|change_enabled|change_on_start)\s*=' "$variety_config" > "$tmp" || true
-      cat >> "$tmp" <<EOF
-      download_folder = ~/Pictures/wallpaper/variety/downloaded
-      fetched_folder = ~/Pictures/wallpaper/variety/fetched
-      favorites_folder = ~/Pictures/wallpaper/variety/favorites
-      copyto_folder = ~/Pictures/wallpaper/variety/favorites
-      wallpaper_auto_rotate = False
-      change_enabled = False
-      change_on_start = False
-      EOF
+      ${pkgs.gnugrep}/bin/grep -Ev '^(download_folder|fetched_folder|favorites_folder|copyto_folder|wallpaper_auto_rotate|change_enabled|change_on_start)[[:space:]]*=' "$variety_config" > "$tmp" || true
+      {
+        printf '%s\n' 'download_folder = ~/Pictures/wallpaper/variety/downloaded'
+        printf '%s\n' 'fetched_folder = ~/Pictures/wallpaper/variety/fetched'
+        printf '%s\n' 'favorites_folder = ~/Pictures/wallpaper/variety/favorites'
+        printf '%s\n' 'copyto_folder = ~/Pictures/wallpaper/variety/favorites'
+        printf '%s\n' 'wallpaper_auto_rotate = False'
+        printf '%s\n' 'change_enabled = False'
+        printf '%s\n' 'change_on_start = False'
+      } >> "$tmp"
       cat "$tmp" > "$variety_config"
       rm -f "$tmp"
       chmod 600 "$variety_config"

--- a/modules/home/hypr.nix
+++ b/modules/home/hypr.nix
@@ -32,7 +32,6 @@ let
     "dub-screenshot"
     "dub-session-doctor"
     "dub-session-reset"
-    "dub-session-start"
     "dub-terminal"
     "dub-waybar-reload"
     "random-wallpaper"
@@ -74,6 +73,10 @@ in
   };
 
   config = lib.mkIf config.dotfiles.profiles.workstation.enable {
+    home.packages = [
+      pkgs.variety
+    ];
+
     xdg.configFile."hypr/hyprland.conf".text = ''
       # GENERATED FILE — DO NOT EDIT DIRECTLY
       # source-of-truth: ryjen/dotfiles
@@ -115,6 +118,36 @@ in
     xdg.configFile."eww/adopted.d/00-empty.conf".source = ../../files/home/.config/eww/adopted.d/empty.conf;
 
     home.file = managedFiles;
+
+    home.activation.configureVarietyWallpaperFolders = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      variety_config="$HOME/.config/variety/variety.conf"
+      variety_downloads="$HOME/Pictures/wallpaper/variety/downloaded"
+      variety_fetched="$HOME/Pictures/wallpaper/variety/fetched"
+      variety_favorites="$HOME/Pictures/wallpaper/variety/favorites"
+
+      mkdir -p "$HOME/.config/variety" \
+        "$variety_downloads" \
+        "$variety_fetched" \
+        "$variety_favorites"
+
+      touch "$variety_config"
+      chmod 600 "$variety_config"
+
+      tmp="$(${pkgs.coreutils}/bin/mktemp)"
+      ${pkgs.gnugrep}/bin/grep -Ev '^(download_folder|fetched_folder|favorites_folder|copyto_folder|wallpaper_auto_rotate|change_enabled|change_on_start)\s*=' "$variety_config" > "$tmp" || true
+      cat >> "$tmp" <<EOF
+      download_folder = ~/Pictures/wallpaper/variety/downloaded
+      fetched_folder = ~/Pictures/wallpaper/variety/fetched
+      favorites_folder = ~/Pictures/wallpaper/variety/favorites
+      copyto_folder = ~/Pictures/wallpaper/variety/favorites
+      wallpaper_auto_rotate = False
+      change_enabled = False
+      change_on_start = False
+      EOF
+      cat "$tmp" > "$variety_config"
+      rm -f "$tmp"
+      chmod 600 "$variety_config"
+    '';
 
     xdg.configFile."hypr/local.conf".text = ''
       # Local Hyprland configuration.

--- a/modules/home/hypr.nix
+++ b/modules/home/hypr.nix
@@ -32,6 +32,7 @@ let
     "dub-screenshot"
     "dub-session-doctor"
     "dub-session-reset"
+    "dub-session-start"
     "dub-terminal"
     "dub-waybar-reload"
     "random-wallpaper"


### PR DESCRIPTION
## Summary

- Install `pkgs.variety` for workstation Hyprland profiles
- Configure writable Variety folders under `~/Pictures/wallpaper/variety`
- Set Variety download, fetched, favorites, and copy-to paths so Hyprpaper's recursive wallpaper rotation can see downloaded images
- Disable Variety's own wallpaper rotation/change-on-start path so Hyprpaper remains the runtime wallpaper daemon

## Notes

Variety expects to mutate `~/.config/variety/variety.conf`, so this PR uses a Home Manager activation step instead of managing `variety.conf` as a read-only XDG config file.

Variety remains an optional downloader/curation UI; Hyprpaper continues to rotate `~/Pictures/wallpaper`.

## Validation

- Inspected the updated Home Manager module on the branch
- Did not run a local Nix/Home Manager switch in this environment