### PR TITLE
[codex] Fix Waybar Nerd Font fallback

### DIFF
--- a/docs/waybar-fonts.md
+++ b/docs/waybar-fonts.md
@@ -1,0 +1,32 @@
+# Waybar Nerd Font troubleshooting
+
+Waybar icon rendering depends on two separate pieces being correct:
+
+1. Nerd Font packages must be installed into the system font set.
+2. Waybar CSS must name font families that fontconfig can actually resolve.
+
+This repo installs both JetBrains Mono Nerd Font and Symbols Nerd Font. Waybar should therefore prefer:
+
+```css
+font-family: "JetBrainsMono Nerd Font Mono", "JetBrainsMono Nerd Font", "Symbols Nerd Font Mono", "Roboto", "sans-serif";
+```
+
+## Local verification
+
+After rebuilding, verify the font names that Waybar is expected to use:
+
+```sh
+fc-match "JetBrainsMono Nerd Font Mono"
+fc-match "JetBrainsMono Nerd Font"
+fc-match "Symbols Nerd Font Mono"
+fc-list | grep -Ei 'JetBrainsMono|Symbols Nerd'
+```
+
+Then restart the user session or restart Waybar after rebuilding:
+
+```sh
+pkill waybar
+waybar &
+```
+
+If icons still render as boxes after those checks, the problem is probably stale session state or a local CSS override in `~/.config/waybar/custom.css`, not missing system font packages.

--- a/files/home/.config/waybar/style.css
+++ b/files/home/.config/waybar/style.css
@@ -6,7 +6,7 @@ window#waybar {
     border: 1px solid rgba(255, 255, 255, 0.1);
     border-radius: 12px;
     margin: 8px 12px;
-    font-family: "JetBrainsMono Nerd Font", "Roboto", "sans-serif";
+    font-family: "JetBrainsMono Nerd Font Mono", "JetBrainsMono Nerd Font", "Symbols Nerd Font Mono", "Roboto", "sans-serif";
     font-size: 16px;
     transition-property: background-color;
     transition-duration: .5s;
@@ -88,7 +88,7 @@ window#waybar {
 }
 
 #idle_inhibitor {
-    font-family: "Symbols Nerd Font Mono", "JetBrainsMono Nerd Font";
+    font-family: "Symbols Nerd Font Mono", "JetBrainsMono Nerd Font Mono", "JetBrainsMono Nerd Font";
     font-size: 20px;
     color: #bb9af7;
     padding: 0 10px;
@@ -143,7 +143,7 @@ window#wofi {
     border: 2px solid #7aa2f7;
     background-color: rgba(26, 27, 38, 0.95);
     border-radius: 12px;
-    font-family: "JetBrainsMono Nerd Font", "Roboto", "sans-serif";
+    font-family: "JetBrainsMono Nerd Font Mono", "JetBrainsMono Nerd Font", "Symbols Nerd Font Mono", "Roboto", "sans-serif";
     font-size: 16px;
 }
 


### PR DESCRIPTION
## Summary

- Update Waybar and Wofi CSS font fallback chains to prefer `JetBrainsMono Nerd Font Mono`
- Add `Symbols Nerd Font Mono` as an explicit fallback for icon glyph coverage
- Add troubleshooting docs for verifying fontconfig and restarting Waybar

## Why

The system font module installs both `nerd-fonts.jetbrains-mono` and `nerd-fonts.symbols-only`, but Waybar CSS was still only asking for `JetBrainsMono Nerd Font` before falling back to non-Nerd fonts. That can leave Waybar icons rendering as boxes even when the system packages are installed.

## Validation

- Inspected `modules/nixos/fonts.nix` on `main`
- Inspected updated `files/home/.config/waybar/style.css` on the branch
- Inspected added `docs/waybar-fonts.md`
- No GitHub workflow runs were found for the branch commits

## Merge note

At review time this branch had diverged from `main` and was behind by a few commits. Rebase/update before merging if GitHub does not do that automatically.