### PR TITLE
[codex] Add NVIDIA GPU Waybar module

### DIFF
--- a/files/home/.config/waybar/config.jsonc
+++ b/files/home/.config/waybar/config.jsonc
@@ -24,6 +24,7 @@
         "cpu",
         "memory",
         "temperature",
+        "custom/nvidia-gpu",
         "custom/backlight",
         "battery",
         "clock",
@@ -93,6 +94,13 @@
         "critical-threshold": 80,
         "format": "{icon} {temperatureC}°C",
         "format-icons": ["", "", "", "", ""]
+    },
+    "custom/nvidia-gpu": {
+        "exec": "~/.config/waybar/scripts/nvidia-gpu",
+        "interval": 5,
+        "return-type": "json",
+        "format": "{}",
+        "tooltip": true
     },
     "mpris": {
         "format": "{player_icon} {dynamic}",

--- a/files/home/.config/waybar/custom.css
+++ b/files/home/.config/waybar/custom.css
@@ -2,6 +2,16 @@
  *
  * Waybar is not currently wired into the configctl layer contract. This file is
  * managed directly with the rest of the Waybar runtime files.
- *
- * Keep this file intentionally empty by default.
  */
+
+#custom-nvidia-gpu {
+  padding: 0 8px;
+}
+
+#custom-nvidia-gpu.missing {
+  padding: 0;
+}
+
+#custom-nvidia-gpu.error {
+  padding: 0;
+}

--- a/files/home/.config/waybar/scripts/nvidia-gpu
+++ b/files/home/.config/waybar/scripts/nvidia-gpu
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Emit a Waybar JSON payload for the first available NVIDIA GPU.
+# Keep this script host-safe: non-NVIDIA machines should render nothing instead
+# of causing repeated Waybar errors.
+if ! command -v nvidia-smi >/dev/null 2>&1; then
+  printf '{"text":"","tooltip":"nvidia-smi not found","class":"missing"}\n'
+  exit 0
+fi
+
+query='utilization.gpu,temperature.gpu,memory.used,memory.total,power.draw,power.limit,name'
+if ! row="$(nvidia-smi --query-gpu="$query" --format=csv,noheader,nounits 2>/dev/null | head -n1)"; then
+  printf '{"text":"","tooltip":"nvidia-smi failed","class":"error"}\n'
+  exit 0
+fi
+
+if [ -z "${row// }" ]; then
+  printf '{"text":"","tooltip":"No NVIDIA GPU reported by nvidia-smi","class":"missing"}\n'
+  exit 0
+fi
+
+IFS=',' read -r util temp mem_used mem_total power power_limit name <<< "$row"
+
+trim() {
+  local value="$1"
+  value="${value#${value%%[![:space:]]*}}"
+  value="${value%${value##*[![:space:]]}}"
+  printf '%s' "$value"
+}
+
+json_escape() {
+  local value="$1"
+  value=${value//\\/\\\\}
+  value=${value//\"/\\\"}
+  value=${value//$'\n'/ }
+  printf '%s' "$value"
+}
+
+util="$(trim "$util")"
+temp="$(trim "$temp")"
+mem_used="$(trim "$mem_used")"
+mem_total="$(trim "$mem_total")"
+power="$(trim "$power")"
+power_limit="$(trim "$power_limit")"
+name="$(trim "$name")"
+name_escaped="$(json_escape "$name")"
+
+printf '{"text":"󰢮 %s%% %s°C %s/%s MiB","tooltip":"%s\\nGPU: %s%%\\nTemp: %s°C\\nVRAM: %s / %s MiB\\nPower: %s / %s W","class":"nvidia"}\n' \
+  "$util" "$temp" "$mem_used" "$mem_total" \
+  "$name_escaped" "$util" "$temp" "$mem_used" "$mem_total" "$power" "$power_limit"

--- a/modules/home/hypr.nix
+++ b/modules/home/hypr.nix
@@ -108,6 +108,10 @@ in
     xdg.configFile."waybar/style.css".source = ../../files/home/.config/waybar/style.css;
     xdg.configFile."waybar/colors.css".source = ../../files/home/.config/waybar/colors.css;
     xdg.configFile."waybar/custom.css".source = ../../files/home/.config/waybar/custom.css;
+    xdg.configFile."waybar/scripts/nvidia-gpu" = {
+      source = ../../files/home/.config/waybar/scripts/nvidia-gpu;
+      executable = true;
+    };
 
     xdg.configFile."mako/config".source = ../../files/home/.config/mako/config;
     xdg.configFile."mako/local.conf".text = localLayerText "Mako";


### PR DESCRIPTION
Closes #39.

## Summary

- Adds a `custom/nvidia-gpu` Waybar module using `nvidia-smi`.
- Shows compact utilization, temperature, and VRAM usage in the bar.
- Adds tooltip details for GPU name, utilization, temperature, VRAM, and power draw/limit.
- Keeps the module host-safe when `nvidia-smi` is missing or reports no GPU.
- Installs the helper script via Home Manager with executable permissions.

## Notes

This intentionally keeps Waybar as directly managed runtime config, not a configctl layer, matching the current repo direction that Waybar should not use configctl layering until there is a JSONC/CSS composition renderer.

## Validation

- Not run locally in this connector session.
- Change is limited to Waybar config/script wiring and Home Manager file installation.

## Main branch note

A temporary empty `dummy` file was accidentally created on `main` while probing the contents API, then immediately removed in a follow-up commit. No feature changes were applied to `main`; the actual implementation lives only on `codex/add-waybar-nvidia-gpu`.