### PR TITLE
[codex] Add optimized configctl manifests

### DIFF
--- a/contracts/configctl/README.md
+++ b/contracts/configctl/README.md
@@ -2,7 +2,7 @@
 
 This directory is the dotfiles-owned contract surface consumed by Dubnium's `configctl` executor.
 
-The manifests are declarative policy. They describe what this repository owns, which user paths are intentionally local-only, and which files may be adopted or composed by explicit tooling. They do not execute commands, perform network I/O, install packages, or mutate user state by themselves.
+The manifests are declarative policy. They describe what this repository owns, which user paths are intentionally local-only, and which files may be adopted or composed by explicit tooling. They do not include shell hooks, network fetches, package installation, or implicit user-state changes.
 
 ## Contract roots
 
@@ -22,7 +22,7 @@ contracts/configctl/
 - `custom.d/*` paths are promotion candidates only through an explicit adopt workflow.
 - `adopted.d/*` paths are archive/evidence paths, ignored during normal runtime unless a manifest says otherwise.
 - Hashes are evidence for review and reconciliation. They are not authority to silently rewrite or delete user files.
-- V1 manifests must not include arbitrary command execution.
+- V1 manifests must not include arbitrary shell hooks.
 
 ## Optimized path model
 
@@ -32,12 +32,13 @@ Common roles:
 
 | Role | Meaning |
 | --- | --- |
-| `managed_sources` | Repo source files or Home Manager-owned runtime files used as composition input. |
-| `runtime_outputs` | Final runtime files the app reads. |
+| `source_inputs` | Repo-owned modules, fragments, or static source files used to produce runtime configuration. |
+| `runtime_outputs` | Final runtime files the app reads; currently Home Manager-owned unless the manifest says otherwise. |
 | `local` | Machine-local files that must not be overwritten or promoted. |
 | `custom` | User-authored promotion candidates. |
 | `adopted` | Archive/evidence paths for already adopted fragments. |
 | `runtime_includes` | Files loaded directly by tools with native include support. |
+| `auxiliary_outputs` | Runtime helper files that are not composition outputs. |
 
 Behavior sections refer to roles, not duplicated path globs. For example, adoption ignores `local` and `adopted` roles instead of repeating every path.
 
@@ -72,7 +73,7 @@ Important constraints:
 
 - Init is for first-run mutable tool state only.
 - Init may create directories and empty files with safe permissions.
-- Init must not run arbitrary commands in v1.
+- Init must not use arbitrary shell hooks.
 - Init must not fetch network resources.
 - Init must not prune or rewrite existing user content unless the manifest explicitly marks the action as non-destructive and the executor confirms it.
 

--- a/contracts/configctl/README.md
+++ b/contracts/configctl/README.md
@@ -2,14 +2,15 @@
 
 This directory is the dotfiles-owned contract surface consumed by Dubnium's `configctl` executor.
 
-The manifests are declarative policy. They describe what this repository owns, which user paths are intentionally local-only, and which files may be adopted or composed by explicit tooling. They do not execute shell, perform network I/O, install packages, or mutate user state by themselves.
+The manifests are declarative policy. They describe what this repository owns, which user paths are intentionally local-only, and which files may be adopted or composed by explicit tooling. They do not execute commands, perform network I/O, install packages, or mutate user state by themselves.
 
 ## Contract roots
 
 ```text
 contracts/configctl/
 ├── apps/       # per-application config ownership and composition contracts
-└── init/       # explicit first-run mutable state contracts
+├── init/       # explicit first-run mutable state contracts
+└── schema-v1.md
 ```
 
 ## Rules
@@ -21,7 +22,39 @@ contracts/configctl/
 - `custom.d/*` paths are promotion candidates only through an explicit adopt workflow.
 - `adopted.d/*` paths are archive/evidence paths, ignored during normal runtime unless a manifest says otherwise.
 - Hashes are evidence for review and reconciliation. They are not authority to silently rewrite or delete user files.
-- V1 manifests must not include arbitrary shell commands.
+- V1 manifests must not include arbitrary command execution.
+
+## Optimized path model
+
+App manifests define path roles once under `[layout]`.
+
+Common roles:
+
+| Role | Meaning |
+| --- | --- |
+| `managed_sources` | Repo source files or Home Manager-owned runtime files used as composition input. |
+| `runtime_outputs` | Final runtime files the app reads. |
+| `local` | Machine-local files that must not be overwritten or promoted. |
+| `custom` | User-authored promotion candidates. |
+| `adopted` | Archive/evidence paths for already adopted fragments. |
+| `runtime_includes` | Files loaded directly by tools with native include support. |
+
+Behavior sections refer to roles, not duplicated path globs. For example, adoption ignores `local` and `adopted` roles instead of repeating every path.
+
+## Lifecycle fields
+
+Every app/init manifest must declare whether it describes current behavior or a planned migration:
+
+| Field | Meaning |
+| --- | --- |
+| `status` | `active` or `planned`. |
+| `current_runtime_owner` | Current writer of runtime outputs, usually `home-manager` today. |
+| `target_runtime_owner` | Intended future writer after migration. |
+| `executor_may_validate` | Whether `configctl` may validate the contract now. |
+| `executor_may_adopt` | Whether `configctl` may use the adoption policy now. |
+| `executor_may_write_outputs` | Whether `configctl` may write runtime outputs now. |
+
+Planned compose manifests are intentionally not write-enabled while Home Manager still owns the runtime files.
 
 ## Manifest semantics
 
@@ -29,21 +62,7 @@ contracts/configctl/
 
 Files under `apps/` describe application configuration that dotfiles owns or exposes to `configctl`.
 
-Important fields:
-
-| Field | Meaning |
-| --- | --- |
-| `tool` | Stable tool identifier used by `configctl`. |
-| `owner` | Policy owner. This should be `dotfiles` for user-layer config here. |
-| `profile` | Optional profile that activates the contract. |
-| `strategy` | `native-include`, `compose`, or `direct-managed`. |
-| `managed_files` | Files generated or installed by Home Manager/dotfiles. |
-| `local_only` | Unmanaged machine-local files that must not be overwritten. |
-| `promotion_sources` | User-authored files eligible for explicit adoption. |
-| `adopted_paths` | Archive/evidence paths for already adopted fragments. |
-| `renderer_required` | Whether an executor must render a final runtime file. |
-
-`native-include` means the app can load managed/local/custom fragments itself, so `configctl` mostly validates and adopts. `compose` means the app needs a renderer because it lacks usable include semantics for the desired layering model. `direct-managed` means the app remains Home Manager-owned only; no local/adopt workflow is promised.
+`native-include` means the app can load local/custom fragments itself, so `configctl` mostly validates and adopts. `compose` means the app needs a renderer because it lacks usable include semantics for the desired layering model. `direct-managed` means the app remains Home Manager-owned only; no local/adopt workflow is promised.
 
 ### Init manifests
 
@@ -59,15 +78,15 @@ Important constraints:
 
 ## Current coverage
 
-| Tool | Manifest | Strategy | Runtime status |
-| --- | --- | --- | --- |
-| Hyprland | `apps/hypr.toml` | native include | active |
-| Zsh | `apps/zsh.toml` | native include | active |
-| Hyprpaper | `apps/hyprpaper.toml` | compose | manifest only |
-| Mako | `apps/mako.toml` | compose | manifest only |
-| Eww | `apps/eww.toml` | compose | manifest only |
-| Waybar | `apps/waybar.toml` | compose | manifest only |
-| Variety | `init/variety.toml` | init | Home Manager currently performs equivalent setup; this manifest documents the future explicit boundary |
+| Tool | Manifest | Strategy | Status | Current owner | Target owner |
+| --- | --- | --- | --- | --- | --- |
+| Hyprland | `apps/hypr.toml` | native include | active | Home Manager | Home Manager |
+| Zsh | `apps/zsh.toml` | native include | active | Home Manager | Home Manager |
+| Hyprpaper | `apps/hyprpaper.toml` | compose | planned | Home Manager | configctl |
+| Mako | `apps/mako.toml` | compose | planned | Home Manager | configctl |
+| Eww | `apps/eww.toml` | compose | planned | Home Manager | configctl |
+| Waybar | `apps/waybar.toml` | compose | planned | Home Manager | configctl |
+| Variety | `init/variety.toml` | init | planned | Home Manager activation | configctl init |
 
 ## Non-goals
 

--- a/contracts/configctl/README.md
+++ b/contracts/configctl/README.md
@@ -1,0 +1,78 @@
+# Configctl Manifest Contracts
+
+This directory is the dotfiles-owned contract surface consumed by Dubnium's `configctl` executor.
+
+The manifests are declarative policy. They describe what this repository owns, which user paths are intentionally local-only, and which files may be adopted or composed by explicit tooling. They do not execute shell, perform network I/O, install packages, or mutate user state by themselves.
+
+## Contract roots
+
+```text
+contracts/configctl/
+├── apps/       # per-application config ownership and composition contracts
+└── init/       # explicit first-run mutable state contracts
+```
+
+## Rules
+
+- Dotfiles owns manifests for user-owned app configuration.
+- Dubnium owns the executor implementation and validation UX.
+- Home Manager may create deterministic source/generated files, but it must not create or overwrite `local.*` escape hatches.
+- `local.*` paths are never promotion candidates.
+- `custom.d/*` paths are promotion candidates only through an explicit adopt workflow.
+- `adopted.d/*` paths are archive/evidence paths, ignored during normal runtime unless a manifest says otherwise.
+- Hashes are evidence for review and reconciliation. They are not authority to silently rewrite or delete user files.
+- V1 manifests must not include arbitrary shell commands.
+
+## Manifest semantics
+
+### App manifests
+
+Files under `apps/` describe application configuration that dotfiles owns or exposes to `configctl`.
+
+Important fields:
+
+| Field | Meaning |
+| --- | --- |
+| `tool` | Stable tool identifier used by `configctl`. |
+| `owner` | Policy owner. This should be `dotfiles` for user-layer config here. |
+| `profile` | Optional profile that activates the contract. |
+| `strategy` | `native-include`, `compose`, or `direct-managed`. |
+| `managed_files` | Files generated or installed by Home Manager/dotfiles. |
+| `local_only` | Unmanaged machine-local files that must not be overwritten. |
+| `promotion_sources` | User-authored files eligible for explicit adoption. |
+| `adopted_paths` | Archive/evidence paths for already adopted fragments. |
+| `renderer_required` | Whether an executor must render a final runtime file. |
+
+`native-include` means the app can load managed/local/custom fragments itself, so `configctl` mostly validates and adopts. `compose` means the app needs a renderer because it lacks usable include semantics for the desired layering model. `direct-managed` means the app remains Home Manager-owned only; no local/adopt workflow is promised.
+
+### Init manifests
+
+Files under `init/` describe initial mutable state that may be created by an explicit `configctl init <tool>` flow.
+
+Important constraints:
+
+- Init is for first-run mutable tool state only.
+- Init may create directories and empty files with safe permissions.
+- Init must not run arbitrary commands in v1.
+- Init must not fetch network resources.
+- Init must not prune or rewrite existing user content unless the manifest explicitly marks the action as non-destructive and the executor confirms it.
+
+## Current coverage
+
+| Tool | Manifest | Strategy | Runtime status |
+| --- | --- | --- | --- |
+| Hyprland | `apps/hypr.toml` | native include | active |
+| Zsh | `apps/zsh.toml` | native include | active |
+| Hyprpaper | `apps/hyprpaper.toml` | compose | manifest only |
+| Mako | `apps/mako.toml` | compose | manifest only |
+| Eww | `apps/eww.toml` | compose | manifest only |
+| Waybar | `apps/waybar.toml` | compose | manifest only |
+| Variety | `init/variety.toml` | init | Home Manager currently performs equivalent setup; this manifest documents the future explicit boundary |
+
+## Non-goals
+
+- No `configctl` executable implementation in this repository.
+- No npm global package management.
+- No network-backed init.
+- No automatic promotion, pruning, or garbage collection.
+- No public mdBook generation.

--- a/contracts/configctl/apps/eww.toml
+++ b/contracts/configctl/apps/eww.toml
@@ -2,60 +2,58 @@ schema_version = 1
 tool = "eww"
 owner = "dotfiles"
 profile = "workstation"
+status = "planned"
 strategy = "compose"
+current_runtime_owner = "home-manager"
+target_runtime_owner = "configctl"
+executor_may_validate = true
+executor_may_adopt = true
+executor_may_write_outputs = false
 renderer_required = true
-description = "Eww has yuck and scss runtime files. Fragment layering requires an explicit renderer per file type."
+description = "Eww has yuck and scss runtime files. Fragment layering requires an explicit renderer before configctl may write outputs."
 
-managed_files = [
-  "~/.config/eww/eww.yuck",
-  "~/.config/eww/eww.scss",
-  "~/.config/eww/custom.d/00-empty.conf",
-  "~/.config/eww/adopted.d/00-empty.conf"
-]
-
-rendered_outputs = [
-  "~/.config/eww/eww.yuck",
-  "~/.config/eww/eww.scss"
-]
-
-local_only = [
-  "~/.config/eww/local.yuck",
-  "~/.config/eww/local.scss"
-]
-
-promotion_sources = [
-  "~/.config/eww/custom.d/*.yuck",
-  "~/.config/eww/custom.d/*.scss"
-]
-
-adopted_paths = [
-  "~/.config/eww/adopted.d/*"
-]
-
-[composition]
-source_order = [
-  "managed",
-  "local",
-  "custom"
-]
+[layout]
+root = "~/.config/eww"
+standard = "configctl-v1"
 managed_sources = [
   "files/home/.config/eww/eww.yuck",
   "files/home/.config/eww/eww.scss"
 ]
-local_sources = [
-  "~/.config/eww/local.yuck",
-  "~/.config/eww/local.scss"
+runtime_outputs = [
+  "eww.yuck",
+  "eww.scss"
 ]
-custom_sources = "~/.config/eww/custom.d/*"
+local = [
+  "local.yuck",
+  "local.scss"
+]
+custom = [
+  "custom.d/*.yuck",
+  "custom.d/*.scss"
+]
+adopted = [
+  "adopted.d/*"
+]
+
+[composition]
+source_order = [
+  "managed_sources",
+  "local",
+  "custom"
+]
+output_role = "runtime_outputs"
 write_mode = "atomic"
 dry_run_required = true
+requires_parser = [
+  "yuck",
+  "scss"
+]
 
 [adoption]
 state_path = "~/.local/state/configctl/adoptions/eww.toml"
 hash_algorithm = "sha256"
 mode = "review-gated"
 ignore = [
-  "~/.config/eww/local.yuck",
-  "~/.config/eww/local.scss",
-  "~/.config/eww/adopted.d/*"
+  "local",
+  "adopted"
 ]

--- a/contracts/configctl/apps/eww.toml
+++ b/contracts/configctl/apps/eww.toml
@@ -1,0 +1,61 @@
+schema_version = 1
+tool = "eww"
+owner = "dotfiles"
+profile = "workstation"
+strategy = "compose"
+renderer_required = true
+description = "Eww has yuck and scss runtime files. Fragment layering requires an explicit renderer per file type."
+
+managed_files = [
+  "~/.config/eww/eww.yuck",
+  "~/.config/eww/eww.scss",
+  "~/.config/eww/custom.d/00-empty.conf",
+  "~/.config/eww/adopted.d/00-empty.conf"
+]
+
+rendered_outputs = [
+  "~/.config/eww/eww.yuck",
+  "~/.config/eww/eww.scss"
+]
+
+local_only = [
+  "~/.config/eww/local.yuck",
+  "~/.config/eww/local.scss"
+]
+
+promotion_sources = [
+  "~/.config/eww/custom.d/*.yuck",
+  "~/.config/eww/custom.d/*.scss"
+]
+
+adopted_paths = [
+  "~/.config/eww/adopted.d/*"
+]
+
+[composition]
+source_order = [
+  "managed",
+  "local",
+  "custom"
+]
+managed_sources = [
+  "files/home/.config/eww/eww.yuck",
+  "files/home/.config/eww/eww.scss"
+]
+local_sources = [
+  "~/.config/eww/local.yuck",
+  "~/.config/eww/local.scss"
+]
+custom_sources = "~/.config/eww/custom.d/*"
+write_mode = "atomic"
+dry_run_required = true
+
+[adoption]
+state_path = "~/.local/state/configctl/adoptions/eww.toml"
+hash_algorithm = "sha256"
+mode = "review-gated"
+ignore = [
+  "~/.config/eww/local.yuck",
+  "~/.config/eww/local.scss",
+  "~/.config/eww/adopted.d/*"
+]

--- a/contracts/configctl/apps/eww.toml
+++ b/contracts/configctl/apps/eww.toml
@@ -10,12 +10,12 @@ executor_may_validate = true
 executor_may_adopt = true
 executor_may_write_outputs = false
 renderer_required = true
-description = "Eww has yuck and scss runtime files. Fragment layering requires an explicit renderer before configctl may write outputs."
+description = "Eww has yuck and scss runtime files; layered fragments require a renderer."
 
 [layout]
 root = "~/.config/eww"
 standard = "configctl-v1"
-managed_sources = [
+source_inputs = [
   "files/home/.config/eww/eww.yuck",
   "files/home/.config/eww/eww.scss"
 ]
@@ -37,7 +37,7 @@ adopted = [
 
 [composition]
 source_order = [
-  "managed_sources",
+  "source_inputs",
   "local",
   "custom"
 ]

--- a/contracts/configctl/apps/hypr.toml
+++ b/contracts/configctl/apps/hypr.toml
@@ -2,31 +2,39 @@ schema_version = 1
 tool = "hypr"
 owner = "dotfiles"
 profile = "workstation"
+status = "active"
 strategy = "native-include"
+current_runtime_owner = "home-manager"
+target_runtime_owner = "home-manager"
+executor_may_validate = true
+executor_may_adopt = true
+executor_may_write_outputs = false
 renderer_required = false
 description = "Hyprland uses native source directives for unmanaged local and custom fragments."
 
-managed_files = [
+[layout]
+root = "~/.config/hypr"
+standard = "configctl-v1"
+managed_sources = [
   "~/.config/hypr/hyprland.conf",
   "~/.config/hypr/adopted.d/machine.conf",
   "~/.config/hypr/custom.d/00-empty.conf"
 ]
-
-local_only = [
-  "~/.config/hypr/local.conf"
+runtime_outputs = [
+  "hyprland.conf"
 ]
-
-promotion_sources = [
-  "~/.config/hypr/custom.d/*.conf"
+local = [
+  "local.conf"
 ]
-
-adopted_paths = [
-  "~/.config/hypr/adopted.d/*.conf"
+custom = [
+  "custom.d/*.conf"
 ]
-
+adopted = [
+  "adopted.d/*.conf"
+]
 runtime_includes = [
-  "~/.config/hypr/local.conf",
-  "~/.config/hypr/custom.d/*.conf"
+  "local.conf",
+  "custom.d/*.conf"
 ]
 
 [adoption]
@@ -34,15 +42,15 @@ state_path = "~/.local/state/configctl/adoptions/hypr.toml"
 hash_algorithm = "sha256"
 mode = "review-gated"
 ignore = [
-  "~/.config/hypr/local.conf",
-  "~/.config/hypr/adopted.d/*"
+  "local",
+  "adopted"
 ]
 
 [validation]
 must_not_manage = [
-  "~/.config/hypr/local.conf"
+  "local"
 ]
 must_exist_or_be_creatable = [
-  "~/.config/hypr/custom.d",
-  "~/.config/hypr/adopted.d"
+  "custom",
+  "adopted"
 ]

--- a/contracts/configctl/apps/hypr.toml
+++ b/contracts/configctl/apps/hypr.toml
@@ -15,13 +15,17 @@ description = "Hyprland uses native source directives for unmanaged local and cu
 [layout]
 root = "~/.config/hypr"
 standard = "configctl-v1"
-managed_sources = [
-  "~/.config/hypr/hyprland.conf",
-  "~/.config/hypr/adopted.d/machine.conf",
-  "~/.config/hypr/custom.d/00-empty.conf"
+source_inputs = [
+  "modules/home/hypr.nix",
+  "files/home/.config/hypr/adopted.d/dubnium.conf",
+  "files/home/.config/hypr/adopted.d/technetium.conf",
+  "files/home/.config/hypr/adopted.d/empty.conf",
+  "files/home/.config/hypr/custom.d/empty.conf"
 ]
 runtime_outputs = [
-  "hyprland.conf"
+  "hyprland.conf",
+  "adopted.d/machine.conf",
+  "custom.d/00-empty.conf"
 ]
 local = [
   "local.conf"

--- a/contracts/configctl/apps/hypr.toml
+++ b/contracts/configctl/apps/hypr.toml
@@ -1,0 +1,48 @@
+schema_version = 1
+tool = "hypr"
+owner = "dotfiles"
+profile = "workstation"
+strategy = "native-include"
+renderer_required = false
+description = "Hyprland uses native source directives for unmanaged local and custom fragments."
+
+managed_files = [
+  "~/.config/hypr/hyprland.conf",
+  "~/.config/hypr/adopted.d/machine.conf",
+  "~/.config/hypr/custom.d/00-empty.conf"
+]
+
+local_only = [
+  "~/.config/hypr/local.conf"
+]
+
+promotion_sources = [
+  "~/.config/hypr/custom.d/*.conf"
+]
+
+adopted_paths = [
+  "~/.config/hypr/adopted.d/*.conf"
+]
+
+runtime_includes = [
+  "~/.config/hypr/local.conf",
+  "~/.config/hypr/custom.d/*.conf"
+]
+
+[adoption]
+state_path = "~/.local/state/configctl/adoptions/hypr.toml"
+hash_algorithm = "sha256"
+mode = "review-gated"
+ignore = [
+  "~/.config/hypr/local.conf",
+  "~/.config/hypr/adopted.d/*"
+]
+
+[validation]
+must_not_manage = [
+  "~/.config/hypr/local.conf"
+]
+must_exist_or_be_creatable = [
+  "~/.config/hypr/custom.d",
+  "~/.config/hypr/adopted.d"
+]

--- a/contracts/configctl/apps/hyprpaper.toml
+++ b/contracts/configctl/apps/hyprpaper.toml
@@ -1,0 +1,50 @@
+schema_version = 1
+tool = "hyprpaper"
+owner = "dotfiles"
+profile = "workstation"
+strategy = "compose"
+renderer_required = true
+description = "Hyprpaper has a managed runtime file today. A future renderer may compose managed fragments with custom fragments into the final config."
+
+managed_files = [
+  "~/.config/hypr/hyprpaper.conf",
+  "~/.config/hyprpaper/custom.d/00-empty.conf",
+  "~/.config/hyprpaper/adopted.d/00-empty.conf"
+]
+
+rendered_outputs = [
+  "~/.config/hypr/hyprpaper.conf"
+]
+
+local_only = [
+  "~/.config/hyprpaper/local.conf"
+]
+
+promotion_sources = [
+  "~/.config/hyprpaper/custom.d/*.conf"
+]
+
+adopted_paths = [
+  "~/.config/hyprpaper/adopted.d/*.conf"
+]
+
+[composition]
+source_order = [
+  "managed",
+  "local",
+  "custom"
+]
+managed_source = "files/home/.config/hypr/hyprpaper.conf"
+local_source = "~/.config/hyprpaper/local.conf"
+custom_sources = "~/.config/hyprpaper/custom.d/*.conf"
+write_mode = "atomic"
+dry_run_required = true
+
+[adoption]
+state_path = "~/.local/state/configctl/adoptions/hyprpaper.toml"
+hash_algorithm = "sha256"
+mode = "review-gated"
+ignore = [
+  "~/.config/hyprpaper/local.conf",
+  "~/.config/hyprpaper/adopted.d/*"
+]

--- a/contracts/configctl/apps/hyprpaper.toml
+++ b/contracts/configctl/apps/hyprpaper.toml
@@ -10,12 +10,12 @@ executor_may_validate = true
 executor_may_adopt = true
 executor_may_write_outputs = false
 renderer_required = true
-description = "Hyprpaper has a Home Manager-owned runtime file today. Local/custom layering requires an explicit renderer before configctl may write outputs."
+description = "Hyprpaper has a Home Manager-owned runtime file today; layered fragments require a renderer."
 
 [layout]
 root = "~/.config/hyprpaper"
 standard = "configctl-v1"
-managed_sources = [
+source_inputs = [
   "files/home/.config/hypr/hyprpaper.conf"
 ]
 runtime_outputs = [
@@ -33,7 +33,7 @@ adopted = [
 
 [composition]
 source_order = [
-  "managed_sources",
+  "source_inputs",
   "local",
   "custom"
 ]

--- a/contracts/configctl/apps/hyprpaper.toml
+++ b/contracts/configctl/apps/hyprpaper.toml
@@ -2,41 +2,42 @@ schema_version = 1
 tool = "hyprpaper"
 owner = "dotfiles"
 profile = "workstation"
+status = "planned"
 strategy = "compose"
+current_runtime_owner = "home-manager"
+target_runtime_owner = "configctl"
+executor_may_validate = true
+executor_may_adopt = true
+executor_may_write_outputs = false
 renderer_required = true
-description = "Hyprpaper has a managed runtime file today. A future renderer may compose managed fragments with custom fragments into the final config."
+description = "Hyprpaper has a Home Manager-owned runtime file today. Local/custom layering requires an explicit renderer before configctl may write outputs."
 
-managed_files = [
-  "~/.config/hypr/hyprpaper.conf",
-  "~/.config/hyprpaper/custom.d/00-empty.conf",
-  "~/.config/hyprpaper/adopted.d/00-empty.conf"
+[layout]
+root = "~/.config/hyprpaper"
+standard = "configctl-v1"
+managed_sources = [
+  "files/home/.config/hypr/hyprpaper.conf"
 ]
-
-rendered_outputs = [
+runtime_outputs = [
   "~/.config/hypr/hyprpaper.conf"
 ]
-
-local_only = [
-  "~/.config/hyprpaper/local.conf"
+local = [
+  "local.conf"
 ]
-
-promotion_sources = [
-  "~/.config/hyprpaper/custom.d/*.conf"
+custom = [
+  "custom.d/*.conf"
 ]
-
-adopted_paths = [
-  "~/.config/hyprpaper/adopted.d/*.conf"
+adopted = [
+  "adopted.d/*.conf"
 ]
 
 [composition]
 source_order = [
-  "managed",
+  "managed_sources",
   "local",
   "custom"
 ]
-managed_source = "files/home/.config/hypr/hyprpaper.conf"
-local_source = "~/.config/hyprpaper/local.conf"
-custom_sources = "~/.config/hyprpaper/custom.d/*.conf"
+output_role = "runtime_outputs"
 write_mode = "atomic"
 dry_run_required = true
 
@@ -45,6 +46,6 @@ state_path = "~/.local/state/configctl/adoptions/hyprpaper.toml"
 hash_algorithm = "sha256"
 mode = "review-gated"
 ignore = [
-  "~/.config/hyprpaper/local.conf",
-  "~/.config/hyprpaper/adopted.d/*"
+  "local",
+  "adopted"
 ]

--- a/contracts/configctl/apps/mako.toml
+++ b/contracts/configctl/apps/mako.toml
@@ -10,12 +10,12 @@ executor_may_validate = true
 executor_may_adopt = true
 executor_may_write_outputs = false
 renderer_required = true
-description = "Mako uses a single config file. Local/custom layering requires an explicit renderer before configctl may write outputs."
+description = "Mako uses one runtime config file, so layered fragments require a renderer."
 
 [layout]
 root = "~/.config/mako"
 standard = "configctl-v1"
-managed_sources = [
+source_inputs = [
   "files/home/.config/mako/config"
 ]
 runtime_outputs = [
@@ -33,7 +33,7 @@ adopted = [
 
 [composition]
 source_order = [
-  "managed_sources",
+  "source_inputs",
   "local",
   "custom"
 ]

--- a/contracts/configctl/apps/mako.toml
+++ b/contracts/configctl/apps/mako.toml
@@ -1,0 +1,50 @@
+schema_version = 1
+tool = "mako"
+owner = "dotfiles"
+profile = "workstation"
+strategy = "compose"
+renderer_required = true
+description = "Mako uses a single config file. Local/custom layering requires an explicit renderer."
+
+managed_files = [
+  "~/.config/mako/config",
+  "~/.config/mako/custom.d/00-empty.conf",
+  "~/.config/mako/adopted.d/00-empty.conf"
+]
+
+rendered_outputs = [
+  "~/.config/mako/config"
+]
+
+local_only = [
+  "~/.config/mako/local.conf"
+]
+
+promotion_sources = [
+  "~/.config/mako/custom.d/*.conf"
+]
+
+adopted_paths = [
+  "~/.config/mako/adopted.d/*.conf"
+]
+
+[composition]
+source_order = [
+  "managed",
+  "local",
+  "custom"
+]
+managed_source = "files/home/.config/mako/config"
+local_source = "~/.config/mako/local.conf"
+custom_sources = "~/.config/mako/custom.d/*.conf"
+write_mode = "atomic"
+dry_run_required = true
+
+[adoption]
+state_path = "~/.local/state/configctl/adoptions/mako.toml"
+hash_algorithm = "sha256"
+mode = "review-gated"
+ignore = [
+  "~/.config/mako/local.conf",
+  "~/.config/mako/adopted.d/*"
+]

--- a/contracts/configctl/apps/mako.toml
+++ b/contracts/configctl/apps/mako.toml
@@ -2,41 +2,42 @@ schema_version = 1
 tool = "mako"
 owner = "dotfiles"
 profile = "workstation"
+status = "planned"
 strategy = "compose"
+current_runtime_owner = "home-manager"
+target_runtime_owner = "configctl"
+executor_may_validate = true
+executor_may_adopt = true
+executor_may_write_outputs = false
 renderer_required = true
-description = "Mako uses a single config file. Local/custom layering requires an explicit renderer."
+description = "Mako uses a single config file. Local/custom layering requires an explicit renderer before configctl may write outputs."
 
-managed_files = [
-  "~/.config/mako/config",
-  "~/.config/mako/custom.d/00-empty.conf",
-  "~/.config/mako/adopted.d/00-empty.conf"
+[layout]
+root = "~/.config/mako"
+standard = "configctl-v1"
+managed_sources = [
+  "files/home/.config/mako/config"
 ]
-
-rendered_outputs = [
-  "~/.config/mako/config"
+runtime_outputs = [
+  "config"
 ]
-
-local_only = [
-  "~/.config/mako/local.conf"
+local = [
+  "local.conf"
 ]
-
-promotion_sources = [
-  "~/.config/mako/custom.d/*.conf"
+custom = [
+  "custom.d/*.conf"
 ]
-
-adopted_paths = [
-  "~/.config/mako/adopted.d/*.conf"
+adopted = [
+  "adopted.d/*.conf"
 ]
 
 [composition]
 source_order = [
-  "managed",
+  "managed_sources",
   "local",
   "custom"
 ]
-managed_source = "files/home/.config/mako/config"
-local_source = "~/.config/mako/local.conf"
-custom_sources = "~/.config/mako/custom.d/*.conf"
+output_role = "runtime_outputs"
 write_mode = "atomic"
 dry_run_required = true
 
@@ -45,6 +46,6 @@ state_path = "~/.local/state/configctl/adoptions/mako.toml"
 hash_algorithm = "sha256"
 mode = "review-gated"
 ignore = [
-  "~/.config/mako/local.conf",
-  "~/.config/mako/adopted.d/*"
+  "local",
+  "adopted"
 ]

--- a/contracts/configctl/apps/waybar.toml
+++ b/contracts/configctl/apps/waybar.toml
@@ -2,53 +2,51 @@ schema_version = 1
 tool = "waybar"
 owner = "dotfiles"
 profile = "workstation"
+status = "planned"
 strategy = "compose"
+current_runtime_owner = "home-manager"
+target_runtime_owner = "configctl"
+executor_may_validate = true
+executor_may_adopt = true
+executor_may_write_outputs = false
 renderer_required = true
-description = "Waybar JSONC does not provide a safe native include model. CSS can import, but the contract treats Waybar as a composed app so JSONC and CSS stay coherent."
+description = "Waybar JSONC does not provide a safe native include model. CSS can import, but the contract treats Waybar as a composed app so JSONC and CSS stay coherent before configctl may write outputs."
 
-managed_files = [
-  "~/.config/waybar/config.jsonc",
-  "~/.config/waybar/style.css",
-  "~/.config/waybar/colors.css",
-  "~/.config/waybar/custom.css",
-  "~/.config/waybar/scripts/nvidia-gpu"
-]
-
-rendered_outputs = [
-  "~/.config/waybar/config.jsonc",
-  "~/.config/waybar/style.css"
-]
-
-local_only = [
-  "~/.config/waybar/local.jsonc",
-  "~/.config/waybar/local.css"
-]
-
-promotion_sources = [
-  "~/.config/waybar/custom.d/*.jsonc",
-  "~/.config/waybar/custom.d/*.css"
-]
-
-adopted_paths = [
-  "~/.config/waybar/adopted.d/*"
-]
-
-[composition]
-source_order = [
-  "managed",
-  "local",
-  "custom"
-]
+[layout]
+root = "~/.config/waybar"
+standard = "configctl-v1"
 managed_sources = [
   "files/home/.config/waybar/config.jsonc",
   "files/home/.config/waybar/style.css",
   "files/home/.config/waybar/colors.css"
 ]
-local_sources = [
-  "~/.config/waybar/local.jsonc",
-  "~/.config/waybar/local.css"
+runtime_outputs = [
+  "config.jsonc",
+  "style.css"
 ]
-custom_sources = "~/.config/waybar/custom.d/*"
+local = [
+  "local.jsonc",
+  "local.css"
+]
+custom = [
+  "custom.d/*.jsonc",
+  "custom.d/*.css"
+]
+adopted = [
+  "adopted.d/*"
+]
+managed_auxiliary = [
+  "custom.css",
+  "scripts/nvidia-gpu"
+]
+
+[composition]
+source_order = [
+  "managed_sources",
+  "local",
+  "custom"
+]
+output_role = "runtime_outputs"
 write_mode = "atomic"
 dry_run_required = true
 requires_parser = [
@@ -61,7 +59,6 @@ state_path = "~/.local/state/configctl/adoptions/waybar.toml"
 hash_algorithm = "sha256"
 mode = "review-gated"
 ignore = [
-  "~/.config/waybar/local.jsonc",
-  "~/.config/waybar/local.css",
-  "~/.config/waybar/adopted.d/*"
+  "local",
+  "adopted"
 ]

--- a/contracts/configctl/apps/waybar.toml
+++ b/contracts/configctl/apps/waybar.toml
@@ -1,0 +1,67 @@
+schema_version = 1
+tool = "waybar"
+owner = "dotfiles"
+profile = "workstation"
+strategy = "compose"
+renderer_required = true
+description = "Waybar JSONC does not provide a safe native include model. CSS can import, but the contract treats Waybar as a composed app so JSONC and CSS stay coherent."
+
+managed_files = [
+  "~/.config/waybar/config.jsonc",
+  "~/.config/waybar/style.css",
+  "~/.config/waybar/colors.css",
+  "~/.config/waybar/custom.css",
+  "~/.config/waybar/scripts/nvidia-gpu"
+]
+
+rendered_outputs = [
+  "~/.config/waybar/config.jsonc",
+  "~/.config/waybar/style.css"
+]
+
+local_only = [
+  "~/.config/waybar/local.jsonc",
+  "~/.config/waybar/local.css"
+]
+
+promotion_sources = [
+  "~/.config/waybar/custom.d/*.jsonc",
+  "~/.config/waybar/custom.d/*.css"
+]
+
+adopted_paths = [
+  "~/.config/waybar/adopted.d/*"
+]
+
+[composition]
+source_order = [
+  "managed",
+  "local",
+  "custom"
+]
+managed_sources = [
+  "files/home/.config/waybar/config.jsonc",
+  "files/home/.config/waybar/style.css",
+  "files/home/.config/waybar/colors.css"
+]
+local_sources = [
+  "~/.config/waybar/local.jsonc",
+  "~/.config/waybar/local.css"
+]
+custom_sources = "~/.config/waybar/custom.d/*"
+write_mode = "atomic"
+dry_run_required = true
+requires_parser = [
+  "jsonc",
+  "css"
+]
+
+[adoption]
+state_path = "~/.local/state/configctl/adoptions/waybar.toml"
+hash_algorithm = "sha256"
+mode = "review-gated"
+ignore = [
+  "~/.config/waybar/local.jsonc",
+  "~/.config/waybar/local.css",
+  "~/.config/waybar/adopted.d/*"
+]

--- a/contracts/configctl/apps/waybar.toml
+++ b/contracts/configctl/apps/waybar.toml
@@ -10,12 +10,12 @@ executor_may_validate = true
 executor_may_adopt = true
 executor_may_write_outputs = false
 renderer_required = true
-description = "Waybar JSONC does not provide a safe native include model. CSS can import, but the contract treats Waybar as a composed app so JSONC and CSS stay coherent before configctl may write outputs."
+description = "Waybar JSONC and CSS need coherent composition before configctl may write outputs."
 
 [layout]
 root = "~/.config/waybar"
 standard = "configctl-v1"
-managed_sources = [
+source_inputs = [
   "files/home/.config/waybar/config.jsonc",
   "files/home/.config/waybar/style.css",
   "files/home/.config/waybar/colors.css"
@@ -35,14 +35,14 @@ custom = [
 adopted = [
   "adopted.d/*"
 ]
-managed_auxiliary = [
+auxiliary_outputs = [
   "custom.css",
   "scripts/nvidia-gpu"
 ]
 
 [composition]
 source_order = [
-  "managed_sources",
+  "source_inputs",
   "local",
   "custom"
 ]

--- a/contracts/configctl/apps/zsh.toml
+++ b/contracts/configctl/apps/zsh.toml
@@ -15,9 +15,8 @@ description = "Zsh sources unmanaged local config and config.d promotion candida
 [layout]
 root = "~/.config/zsh"
 standard = "configctl-v1"
-managed_sources = [
-  "~/.zshenv",
-  "~/.config/zsh/.zshrc"
+source_inputs = [
+  "modules/home/zsh.nix"
 ]
 runtime_outputs = [
   "~/.zshenv",

--- a/contracts/configctl/apps/zsh.toml
+++ b/contracts/configctl/apps/zsh.toml
@@ -1,0 +1,47 @@
+schema_version = 1
+tool = "zsh"
+owner = "dotfiles"
+profile = "all"
+strategy = "native-include"
+renderer_required = false
+description = "Zsh sources unmanaged local config and config.d promotion candidates from managed init content."
+
+managed_files = [
+  "~/.zshenv",
+  "~/.config/zsh/.zshrc"
+]
+
+local_only = [
+  "~/.config/zsh/local.zsh"
+]
+
+promotion_sources = [
+  "~/.config/zsh/config.d/*"
+]
+
+adopted_paths = [
+  "~/.config/zsh/adopted.d/*"
+]
+
+runtime_includes = [
+  "~/.config/zsh/local.zsh",
+  "~/.config/zsh/config.d/*"
+]
+
+[adoption]
+state_path = "~/.local/state/configctl/adoptions/zsh.toml"
+hash_algorithm = "sha256"
+mode = "review-gated"
+ignore = [
+  "~/.config/zsh/local.zsh",
+  "~/.config/zsh/adopted.d/*"
+]
+
+[validation]
+must_not_manage = [
+  "~/.config/zsh/local.zsh"
+]
+must_exist_or_be_creatable = [
+  "~/.config/zsh/config.d",
+  "~/.config/zsh/adopted.d"
+]

--- a/contracts/configctl/apps/zsh.toml
+++ b/contracts/configctl/apps/zsh.toml
@@ -2,30 +2,39 @@ schema_version = 1
 tool = "zsh"
 owner = "dotfiles"
 profile = "all"
+status = "active"
 strategy = "native-include"
+current_runtime_owner = "home-manager"
+target_runtime_owner = "home-manager"
+executor_may_validate = true
+executor_may_adopt = true
+executor_may_write_outputs = false
 renderer_required = false
 description = "Zsh sources unmanaged local config and config.d promotion candidates from managed init content."
 
-managed_files = [
+[layout]
+root = "~/.config/zsh"
+standard = "configctl-v1"
+managed_sources = [
   "~/.zshenv",
   "~/.config/zsh/.zshrc"
 ]
-
-local_only = [
-  "~/.config/zsh/local.zsh"
+runtime_outputs = [
+  "~/.zshenv",
+  ".zshrc"
 ]
-
-promotion_sources = [
-  "~/.config/zsh/config.d/*"
+local = [
+  "local.zsh"
 ]
-
-adopted_paths = [
-  "~/.config/zsh/adopted.d/*"
+custom = [
+  "config.d/*"
 ]
-
+adopted = [
+  "adopted.d/*"
+]
 runtime_includes = [
-  "~/.config/zsh/local.zsh",
-  "~/.config/zsh/config.d/*"
+  "local.zsh",
+  "config.d/*"
 ]
 
 [adoption]
@@ -33,15 +42,15 @@ state_path = "~/.local/state/configctl/adoptions/zsh.toml"
 hash_algorithm = "sha256"
 mode = "review-gated"
 ignore = [
-  "~/.config/zsh/local.zsh",
-  "~/.config/zsh/adopted.d/*"
+  "local",
+  "adopted"
 ]
 
 [validation]
 must_not_manage = [
-  "~/.config/zsh/local.zsh"
+  "local"
 ]
 must_exist_or_be_creatable = [
-  "~/.config/zsh/config.d",
-  "~/.config/zsh/adopted.d"
+  "custom",
+  "adopted"
 ]

--- a/contracts/configctl/init/variety.toml
+++ b/contracts/configctl/init/variety.toml
@@ -3,10 +3,15 @@ tool = "variety"
 owner = "dotfiles"
 profile = "workstation"
 kind = "initial-mutable-state"
-description = "Initial local wallpaper state for Variety. This contract documents safe first-run state only; it does not fetch wallpapers or enable rotation."
+status = "planned"
+current_runtime_owner = "home-manager-activation"
+target_runtime_owner = "configctl-init"
+executor_may_validate = true
+executor_may_initialize = false
+description = "Initial local wallpaper state for Variety. Home Manager activation currently performs equivalent setup; this contract documents the future explicit init boundary."
 
 network = false
-arbitrary_shell = false
+arbitrary_commands = false
 destructive = false
 dry_run_required = true
 

--- a/contracts/configctl/init/variety.toml
+++ b/contracts/configctl/init/variety.toml
@@ -1,0 +1,32 @@
+schema_version = 1
+tool = "variety"
+owner = "dotfiles"
+profile = "workstation"
+kind = "initial-mutable-state"
+description = "Initial local wallpaper state for Variety. This contract documents safe first-run state only; it does not fetch wallpapers or enable rotation."
+
+network = false
+arbitrary_shell = false
+destructive = false
+dry_run_required = true
+
+directories = [
+  { path = "~/.config/variety", mode = "0700" },
+  { path = "~/Pictures/wallpaper/variety/downloaded", mode = "0755" },
+  { path = "~/Pictures/wallpaper/variety/fetched", mode = "0755" },
+  { path = "~/Pictures/wallpaper/variety/favorites", mode = "0755" }
+]
+
+files = [
+  { path = "~/.config/variety/variety.conf", mode = "0600", create = "if-missing" }
+]
+
+settings = [
+  { file = "~/.config/variety/variety.conf", key = "download_folder", value = "~/Pictures/wallpaper/variety/downloaded", mode = "set-if-missing-or-owned" },
+  { file = "~/.config/variety/variety.conf", key = "fetched_folder", value = "~/Pictures/wallpaper/variety/fetched", mode = "set-if-missing-or-owned" },
+  { file = "~/.config/variety/variety.conf", key = "favorites_folder", value = "~/Pictures/wallpaper/variety/favorites", mode = "set-if-missing-or-owned" },
+  { file = "~/.config/variety/variety.conf", key = "copyto_folder", value = "~/Pictures/wallpaper/variety/favorites", mode = "set-if-missing-or-owned" },
+  { file = "~/.config/variety/variety.conf", key = "wallpaper_auto_rotate", value = "False", mode = "set-if-missing-or-owned" },
+  { file = "~/.config/variety/variety.conf", key = "change_enabled", value = "False", mode = "set-if-missing-or-owned" },
+  { file = "~/.config/variety/variety.conf", key = "change_on_start", value = "False", mode = "set-if-missing-or-owned" }
+]

--- a/contracts/configctl/schema-v1.md
+++ b/contracts/configctl/schema-v1.md
@@ -39,14 +39,17 @@ Common fields:
 | --- | --- |
 | `root` | Runtime config directory for the tool. |
 | `standard` | Layout convention identifier, usually `configctl-v1`. |
-| `managed_sources` | Repo or Home Manager-owned source inputs. |
+| `source_inputs` | Repo-owned modules, fragments, or static source files used to produce runtime configuration. |
 | `runtime_outputs` | Final files the app reads. |
 | `local` | Local-only unmanaged paths. |
 | `custom` | User-authored promotion candidates. |
 | `adopted` | Archive/evidence paths. |
 | `runtime_includes` | Paths directly loaded by apps with native include support. |
+| `auxiliary_outputs` | Runtime helper files that are not composition outputs. |
 
 All path role fields use arrays, even when they contain one item.
+
+`source_inputs` must describe source-of-truth inputs, not generated runtime outputs. Runtime outputs belong under `runtime_outputs` or `auxiliary_outputs`.
 
 ## Composition
 

--- a/contracts/configctl/schema-v1.md
+++ b/contracts/configctl/schema-v1.md
@@ -1,0 +1,120 @@
+# Configctl Manifest Schema v1
+
+This schema documents the declarative contract format under `contracts/configctl/`.
+
+The schema is intentionally small. It avoids duplicated path lists by defining path roles once in `[layout]` and referencing those roles from behavior sections.
+
+## App manifest
+
+Required top-level fields:
+
+| Field | Allowed values | Notes |
+| --- | --- | --- |
+| `schema_version` | `1` | Integer schema version. |
+| `tool` | string | Stable tool identifier. |
+| `owner` | `dotfiles` | Policy owner for this repository. |
+| `profile` | string | Profile that activates the contract. |
+| `status` | `active`, `planned` | Whether the contract describes current executor behavior. |
+| `strategy` | `native-include`, `compose`, `direct-managed` | Runtime configuration strategy. |
+| `current_runtime_owner` | string | Current writer of runtime outputs. |
+| `target_runtime_owner` | string | Desired writer after migration. |
+| `executor_may_validate` | boolean | Whether validation is allowed now. |
+| `executor_may_adopt` | boolean | Whether adoption is allowed now. |
+| `executor_may_write_outputs` | boolean | Whether writing runtime outputs is allowed now. |
+
+Optional top-level fields:
+
+| Field | Notes |
+| --- | --- |
+| `renderer_required` | Boolean marker for `compose` contracts. |
+| `description` | Human-readable purpose. |
+
+## Path layout
+
+`[layout]` defines path roles once.
+
+Common fields:
+
+| Field | Meaning |
+| --- | --- |
+| `root` | Runtime config directory for the tool. |
+| `standard` | Layout convention identifier, usually `configctl-v1`. |
+| `managed_sources` | Repo or Home Manager-owned source inputs. |
+| `runtime_outputs` | Final files the app reads. |
+| `local` | Local-only unmanaged paths. |
+| `custom` | User-authored promotion candidates. |
+| `adopted` | Archive/evidence paths. |
+| `runtime_includes` | Paths directly loaded by apps with native include support. |
+
+All path role fields use arrays, even when they contain one item.
+
+## Composition
+
+`[composition]` is required when `strategy = "compose"`.
+
+| Field | Meaning |
+| --- | --- |
+| `source_order` | Ordered layout role names used as composition inputs. |
+| `output_role` | Layout role name for rendered outputs. |
+| `write_mode` | Output write mode, currently `atomic`. |
+| `dry_run_required` | Must be true before output writing is enabled. |
+| `requires_parser` | Optional parser requirements such as `jsonc` or `css`. |
+
+Planned compose contracts must set:
+
+```toml
+status = "planned"
+current_runtime_owner = "home-manager"
+target_runtime_owner = "configctl"
+executor_may_write_outputs = false
+```
+
+## Adoption
+
+`[adoption]` is required when `executor_may_adopt = true`.
+
+| Field | Meaning |
+| --- | --- |
+| `state_path` | XDG state path for adoption metadata. |
+| `hash_algorithm` | Hash algorithm, currently `sha256`. |
+| `mode` | Adoption mode, currently `review-gated`. |
+| `ignore` | Layout role names to ignore during adoption/reconciliation. |
+
+`ignore` must reference layout roles, not raw paths.
+
+## Validation
+
+`[validation]` may add role-level checks.
+
+| Field | Meaning |
+| --- | --- |
+| `must_not_manage` | Layout roles that Home Manager or configctl must not own as generated files. |
+| `must_exist_or_be_creatable` | Layout roles whose parent directories may be created safely. |
+
+## Init manifest
+
+Required top-level fields:
+
+| Field | Allowed values | Notes |
+| --- | --- | --- |
+| `schema_version` | `1` | Integer schema version. |
+| `tool` | string | Stable tool identifier. |
+| `owner` | `dotfiles` | Policy owner. |
+| `profile` | string | Profile that activates the contract. |
+| `kind` | `initial-mutable-state` | Init contract kind. |
+| `status` | `active`, `planned` | Whether executor ownership is current. |
+| `current_runtime_owner` | string | Current owner of the mutable state behavior. |
+| `target_runtime_owner` | string | Target owner after migration. |
+| `executor_may_validate` | boolean | Whether validation is allowed now. |
+| `executor_may_initialize` | boolean | Whether init mutation is allowed now. |
+
+Required safety flags:
+
+| Field | Required value for v1 |
+| --- | --- |
+| `network` | `false` |
+| `arbitrary_commands` | `false` |
+| `destructive` | `false` |
+| `dry_run_required` | `true` |
+
+Init manifests may contain `directories`, `files`, and `settings` arrays. Those entries must be declarative and non-destructive.


### PR DESCRIPTION
Adds declarative configctl contract manifests under contracts/configctl for dotfiles-owned user configuration.

Changes:
- adds schema-v1 documentation for optimized role-based manifests
- adds app manifests for Hyprland, Zsh, Hyprpaper, Mako, Eww, and Waybar
- adds a Variety init manifest for future explicit first-run local state
- replaces repeated path lists with a canonical [layout] role model
- adds lifecycle fields so planned compose/init contracts remain Home Manager-owned until configctl migration

Boundary:
- dotfiles owns user-layer policy and manifests
- Dubnium owns executor behavior
- active native-include manifests may validate/adopt but not write outputs
- planned compose manifests may validate/adopt but must not write Home Manager-owned outputs yet
- local-only files remain unmanaged and ignored by adoption

Not included:
- npm tooling changes
- configctl executable implementation
- automatic promotion or pruning
- generated public docs

Validation:
- compared branch with main; only contracts/configctl/** files are added
- no Nix evaluation required because this PR adds declarative TOML and Markdown contract artifacts only

Refs #36