### PR TITLE
Scope Waybar laptop modules to technetium

### DIFF
--- a/files/home/.config/waybar/config-technetium.jsonc
+++ b/files/home/.config/waybar/config-technetium.jsonc
@@ -1,0 +1,182 @@
+// -*- mode: jsonc -*-
+{
+    "layer": "top",
+    "position": "top",
+    "spacing": 10,
+    "height": 42,
+    "exclusive": true,
+    "passthrough": false,
+    "fixed-center": true,
+    "ipc": true,
+    "modules-left": [
+        "hyprland/workspaces",
+        "hyprland/submap",
+        "custom/media"
+    ],
+    "modules-center": [
+        "hyprland/window"
+    ],
+    "modules-right": [
+        "mpris",
+        "idle_inhibitor",
+        "pulseaudio",
+        "power-profiles-daemon",
+        "cpu",
+        "memory",
+        "temperature",
+        "custom/nvidia-gpu",
+        "custom/backlight",
+        "battery",
+        "clock",
+        "hyprland/language",
+        "custom/power"
+    ],
+    "hyprland/workspaces": {
+        "disable-scroll": true,
+        "all-outputs": true,
+        "active-only": false,
+        "format": "{name}: {icon}",
+        "format-icons": {
+            "1": "",
+            "2": "",
+            "3": "",
+            "urgent": "",
+            "active": "",
+            "default": ""
+        }
+    },
+    "hyprland/window": {
+        "format": "{title}",
+        "max-length": 40,
+        "separate-outputs": true,
+        "rewrite": {
+            "(.*) — Mozilla Firefox": "󰈹 Firefox",
+            "(.*) - Visual Studio Code": "󰨞 Code",
+            "(.*) - Alacritty": " Terminal",
+            "": "Desktop"
+        }
+    },
+    "hyprland/language": {
+        "format": "  {}",
+        "format-en": "US",
+        "format-colemak": "CMK",
+        "on-click": "hyprctl switchxkblayout all next"
+    },
+    "hyprland/submap": {
+        "format": "<span style=\"italic\">{}</span>"
+    },
+    "cpu": {
+        "format": "{usage}% ",
+        "on-click": "alacritty --title 'btop' -e sh -c 'btop'"
+    },
+    "memory": {
+        "format": "{}% ",
+        "on-click": "alacritty --title 'btop' -e sh -c 'btop'"
+    },
+    "backlight": {
+        "device": "intel_backlight",
+        "format": "{icon} {percent}%",
+        "format-icons": ["", "", "", "", "", "", "", "", ""],
+        "on-scroll-up": "brightnessctl set 1%+",
+        "on-scroll-down": "brightnessctl set 1%-",
+        "min-length": 6
+    },
+    "custom/backlight": {
+        "exec": "brightnessctl -m | cut -d, -f4",
+        "interval": 1,
+        "format": "󰃠 {}",
+        "on-scroll-up": "brightnessctl set 1%+",
+        "on-scroll-down": "brightnessctl set 1%-",
+        "tooltip": false
+    },
+    "temperature": {
+        "critical-threshold": 80,
+        "format": "{icon} {temperatureC}°C",
+        "format-icons": ["", "", "", "", ""]
+    },
+    "custom/nvidia-gpu": {
+        "exec": "~/.config/waybar/scripts/nvidia-gpu",
+        "interval": 5,
+        "return-type": "json",
+        "format": "{}",
+        "tooltip": true
+    },
+    "mpris": {
+        "format": "{player_icon} {dynamic}",
+        "format-paused": "{status_icon} <i>{dynamic}</i>",
+        "player-icons": {
+            "default": "▶",
+            "spotify": "",
+            "firefox": "",
+            "chrome": ""
+        },
+        "status-icons": {
+            "paused": "⏸"
+        },
+        "max-length": 30
+    },
+    "battery": {
+        "states": {
+            "good": 95,
+            "warning": 30,
+            "critical": 15
+        },
+        "format": "{icon} {capacity}%",
+        "format-charging": "󰂄 {capacity}%",
+        "format-plugged": " {capacity}%",
+        "format-discharging": "{icon} {capacity}%",
+        "format-full": "󰁹 {capacity}%",
+        "format-icons": ["󰂎", "󰁺", "󰁻", "󰁼", "󰁽", "󰁾", "󰁿", "󰂀", "󰂁", "󰂂", "󰁹"],
+        "on-click": "alacritty -e sudo powertop",
+        "tooltip": true,
+        "interval": 5,
+        "bat": "BAT0"
+    },
+    "pulseaudio": {
+        "format": "{volume}% {icon} {format_source}",
+        "format-bluetooth": "{volume}% {icon} {format_source}",
+        "format-muted": " {format_source}",
+        "format-source": "{volume}% ",
+        "format-source-muted": "",
+        "format-icons": {
+            "headphone": "",
+            "default": ["", "", ""]
+        },
+        "on-click": "pavucontrol"
+    },
+    "network": {
+        "format-wifi": "{essid} ({signalStrength}%) ",
+        "format-ethernet": "{ipaddr}/{cidr} ",
+        "tooltip-format": "{ifname} via {gwaddr} ",
+        "format-disconnected": "Disconnected ⚠",
+        "on-click": "nm-connection-editor"
+    },
+    "idle_inhibitor": {
+        "format": "<span font='12'>{icon}</span>",
+        "format-icons": {
+            "activated": "󰛐",
+            "deactivated": "󰛑"
+        },
+        "tooltip": true
+    },
+    "clock": {
+        "format": "{:%I:%M %p}",
+        "tooltip-format": "<big>{:%Y %B}</big>\n<tt><small>{calendar}</small></tt>",
+        "on-click": "gsimplecal"
+    },
+    "custom/media": {
+        "format": "{icon} {}",
+        "return-type": "json",
+        "max-length": 40,
+        "format-icons": {
+            "spotify": "",
+            "default": "🎜"
+        },
+        "escape": true,
+        "exec": "playerctl -a metadata --format '{\"text\": \"{{artist}} - {{title}}\", \"alt\": \"{{status}}\", \"class\": \"{{status}}\"}' --follow"
+    },
+    "custom/power": {
+        "format": "⏻ ",
+        "on-click": "wlogout"
+    }
+}

--- a/files/home/.config/waybar/config.jsonc
+++ b/files/home/.config/waybar/config.jsonc
@@ -26,9 +26,7 @@
         "temperature",
         "custom/nvidia-gpu",
         "custom/backlight",
-        "battery",
         "clock",
-        "tray",
         "hyprland/language",
         "custom/power"
     ],

--- a/home/ryjen/profiles/technetium.nix
+++ b/home/ryjen/profiles/technetium.nix
@@ -1,8 +1,10 @@
-{ ... }:
+{ lib, ... }:
 {
   dotfiles.profiles.workstation.enable = true;
   dotfiles.profiles.browser.enable = true;
   dotfiles.profiles.android.enable = false;
   dotfiles.profiles.micrantha.enable = false;
   dotfiles.hypr.adoptedProfile = "technetium";
+
+  xdg.configFile."waybar/config.jsonc".source = lib.mkForce ../../../files/home/.config/waybar/config-technetium.jsonc;
 }


### PR DESCRIPTION
## Summary

- removes inactive `battery` and `tray` modules from the default Waybar module list
- adds a technetium-specific Waybar config that keeps the `battery` module but still drops the empty `tray`
- makes the technetium profile override the default Waybar config with the laptop variant

## Notes

- Kept this as a narrow profile override instead of introducing a full Waybar renderer/config composition layer.
- Did not touch `main`; changes are isolated to `codex/waybar-host-modules`.

## Validation

- Inspected the rendered module lists through the GitHub connector:
  - default config no longer lists `battery` or `tray`
  - technetium config lists `battery` and not `tray`
- Not run locally: sandbox has no GitHub network access for cloning/evaluating the flake.