### PR TITLE
Use dubnium profile for nixos workstation

### DIFF
--- a/home/ryjen/profiles/nixos.nix
+++ b/home/ryjen/profiles/nixos.nix
@@ -1,8 +1,10 @@
-{ ... }:
+{ lib, ... }:
 {
   dotfiles.agents.hermes.enable = true;
   dotfiles.profiles.workstation.enable = true;
   dotfiles.profiles.android.enable = true;
   dotfiles.profiles.micrantha.enable = true;
   dotfiles.hypr.adoptedProfile = "technetium";
+
+  xdg.configFile."waybar/config.jsonc".source = lib.mkForce ../../../files/home/.config/waybar/config-technetium.jsonc;
 }

--- a/home/ryjen/profiles/nixos.nix
+++ b/home/ryjen/profiles/nixos.nix
@@ -1,10 +1,8 @@
-{ lib, ... }:
+{ ... }:
 {
   dotfiles.agents.hermes.enable = true;
   dotfiles.profiles.workstation.enable = true;
   dotfiles.profiles.android.enable = true;
   dotfiles.profiles.micrantha.enable = true;
-  dotfiles.hypr.adoptedProfile = "technetium";
-
-  xdg.configFile."waybar/config.jsonc".source = lib.mkForce ../../../files/home/.config/waybar/config-technetium.jsonc;
+  dotfiles.hypr.adoptedProfile = "dubnium";
 }


### PR DESCRIPTION
## Summary

- treats `home/ryjen/profiles/nixos.nix` as the Dubnium workstation profile
- changes the adopted Hypr profile from `technetium` to `dubnium`
- keeps `ryjen@nixos` on the default Waybar config, without the laptop battery module

## Context

PR #45 removed laptop-only and empty Waybar modules from the default Waybar config, while keeping the battery module in the technetium-specific Waybar config. The `ryjen@nixos` path should represent the Dubnium workstation, not the Technetium laptop.

A fuller explicit host model for `technetium` can be handled as a separate follow-up if the flake output structure needs to distinguish host entries more clearly.

## Validation

- Inspected the PR diff and confirmed the only file change is `home/ryjen/profiles/nixos.nix`.
- Confirmed the diff changes the adopted profile from `technetium` to `dubnium`.
- Confirmed the PR no longer adds a laptop Waybar override to `profiles/nixos.nix`.
- Not run locally: sandbox has no GitHub network access for cloning or evaluating the flake.