### PR TITLE
[codex] Gate Waybar battery to technetium

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ Tracked profile entrypoints:
 - `home/USERNAME/profiles/verify.nix` for lightweight verification without Android or other machine-specific overlays
 - `modules/home/verify.nix` for the lightweight shared module set used by verification
 
+Current Home Manager host contract:
+
+- `ryjen@dubnium` is the graphical workstation path. It enables Hyprland/Waybar and uses the workstation-safe Waybar config without a laptop battery module.
+- `ryjen@technetium` is the graphical laptop path. It enables Hyprland/Waybar and force-selects the Technetium Waybar config with the battery module.
+- `ryjen@nixos` is a compatibility alias for the main NixOS/workstation path. It must not imply Technetium or laptop-specific behavior.
+- `ryjen@verify` and other non-graphical verification paths remain lightweight and do not enable GUI, Hyprland, or Waybar by default.
+
 Architecture rationale lives in `docs/architecture/adr-0001-baseline-and-overlays.md`.
 
 The layered home configuration contract lives in `docs/architecture/home-layering-contract.md`.
@@ -167,4 +174,14 @@ Lightweight verification outputs:
 
 ```bash
 nix flake check --no-build
+```
+
+Home Manager host smoke checks:
+
+```bash
+nix build .#homeConfigurations.ryjen@dubnium.activationPackage
+nix build .#homeConfigurations.ryjen@technetium.activationPackage
+nix build .#homeConfigurations.ryjen@nixos.activationPackage
+nix build .#homeConfigurations.ryjen@verify.activationPackage
+nix run .#verify-session-files
 ```

--- a/files/home/.config/waybar/config.jsonc
+++ b/files/home/.config/waybar/config.jsonc
@@ -114,23 +114,6 @@
         },
         "max-length": 30
     },
-    "battery": {
-        "states": {
-            "good": 95,
-            "warning": 30,
-            "critical": 15
-        },
-        "format": "{icon} {capacity}%",
-        "format-charging": "󰂄 {capacity}%",
-        "format-plugged": " {capacity}%",
-        "format-discharging": "{icon} {capacity}%",
-        "format-full": "󰁹 {capacity}%",
-        "format-icons": ["󰂎", "󰁺", "󰁻", "󰁼", "󰁽", "󰁾", "󰁿", "󰂀", "󰂁", "󰂂", "󰁹"],
-        "on-click": "alacritty -e sudo powertop",
-        "tooltip": true,
-        "interval": 5,
-        "bat": "BAT0"
-    },
     "pulseaudio": {
         "format": "{volume}% {icon} {format_source}",
         "format-bluetooth": "{volume}% {icon} {format_source}",


### PR DESCRIPTION
## What changed

- Removed the stale `battery` module definition from the base Waybar config.
- Left the base Waybar `modules-right` workstation-safe: no active `battery` module.
- Left Technetium's laptop-specific Waybar config unchanged, including the active `battery` module and battery configuration block.
- Documented the current Home Manager host contract and host smoke commands in `README.md`.

## Confirmed host matrix behavior

- `ryjen@dubnium`: graphical Waybar, no battery module.
- `ryjen@technetium`: graphical Waybar with battery module.
- `ryjen@nixos`: compatibility workstation path, not laptop behavior.
- `verify` / non-graphical paths: no GUI/Waybar by default.

## Tray audit

- `tray` was found inactive in the fetched current Waybar configs, so no tray gating/removal was needed in this slice.

## Validation performed

Read-only/connector validation performed:

- Audited current profile/Waybar coupling for `adoptedProfile`, `technetium`, `battery`, `tray`, `waybar`, `hypr`, `homeConfigurations`, `ryjen@nixos`, `headless`, and `wsl`-adjacent references.
- Read back `files/home/.config/waybar/config.jsonc` on this branch and confirmed `modules-right` has no `battery` entry and the stale `battery` config block is removed.
- Read back `files/home/.config/waybar/config-technetium.jsonc` on this branch and confirmed `modules-right` still includes `battery` and the battery config block remains.
- Read back `home/ryjen/profiles/nixos.nix`, `home/ryjen/profiles/dubnium.nix`, `home/ryjen/profiles/technetium.nix`, and `home/ryjen/profiles/verify.nix` to confirm this slice did not alter the profile split.
- Read back `flake.nix` and confirmed the existing `ryjen@nixos`, `ryjen@verify`, `ryjen@dubnium`, and `ryjen@technetium` Home Manager outputs remain present.

Not run locally:

- `nix build .#homeConfigurations.ryjen@dubnium.activationPackage`
- `nix build .#homeConfigurations.ryjen@technetium.activationPackage`
- `nix build .#homeConfigurations.ryjen@nixos.activationPackage`
- `nix build .#homeConfigurations.ryjen@verify.activationPackage`
- `nix run .#verify-session-files`

Reason: this execution container cannot resolve `github.com`, so it could not clone/fetch the branch or dependencies for local Nix validation.

## Later slices left out intentionally

- Explicit graphical/laptop/workstation/headless/wsl profile split.
- Proper regression checks/assertions for host/profile ownership.
- `configctl` composition work, if still desired.