### PR TITLE
Validate flake script executables

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -87,6 +87,11 @@
         };
       };
 
+      checks.${system}.flake-script-executables = pkgs.runCommand "flake-script-executables" { nativeBuildInputs = [ pkgs.git ]; } ''
+        ${./scripts/verify-flake-script-executables.sh} ${self}
+        touch "$out"
+      '';
+
       packages.${system} = {
         hermes-agent = hermes-agent.packages.${system}.default;
       };

--- a/scripts/verify-flake-script-executables.sh
+++ b/scripts/verify-flake-script-executables.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env sh
+set -eu
+
+if [ "$#" -gt 1 ]; then
+  echo "usage: $0 [repo-root]" >&2
+  exit 2
+fi
+
+if [ "$#" -eq 1 ]; then
+  repo_root="$1"
+else
+  repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+fi
+
+flake_file="$repo_root/flake.nix"
+
+if [ ! -f "$flake_file" ]; then
+  echo "missing flake.nix at $flake_file" >&2
+  exit 1
+fi
+
+script_refs="$(
+  grep -Eo '\./scripts/[^"[:space:]}]+' "$flake_file" \
+    | sed 's|^\./||' \
+    | sort -u
+)"
+
+if [ -z "$script_refs" ]; then
+  echo "no ./scripts/... references found in flake.nix"
+  exit 0
+fi
+
+status=0
+
+fail() {
+  printf '[fail] %s\n' "$*" >&2
+  status=1
+}
+
+ok() {
+  printf '[ok] %s\n' "$*"
+}
+
+is_git_checkout=false
+if git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  is_git_checkout=true
+fi
+
+printf 'Verifying flake script executable contract\n\n'
+
+for script_ref in $script_refs; do
+  script_path="$repo_root/$script_ref"
+
+  if [ ! -f "$script_path" ]; then
+    fail "$script_ref missing"
+    continue
+  fi
+
+  if [ ! -x "$script_path" ]; then
+    fail "$script_ref is not executable on disk"
+  else
+    ok "$script_ref executable on disk"
+  fi
+
+  if [ "$is_git_checkout" = true ]; then
+    index_mode="$(git -C "$repo_root" ls-files --stage -- "$script_ref" | awk '{ print $1 }')"
+
+    if [ -z "$index_mode" ]; then
+      fail "$script_ref is not tracked in Git"
+    elif [ "$index_mode" != "100755" ]; then
+      fail "$script_ref has Git index mode $index_mode, expected 100755"
+    else
+      ok "$script_ref executable in Git index"
+    fi
+  fi
+done
+
+exit "$status"


### PR DESCRIPTION
## Summary

- Inspected the current `flake.nix` script-backed flake app targets:
  - `scripts/verify-in-container.sh`
  - `scripts/verify-session-files.sh`
  - `scripts/verify-neovim-config.sh`
- Added `scripts/verify-flake-script-executables.sh` as a lightweight regression guard.
- Added `checks.x86_64-linux.flake-script-executables` as a thin Nix check wrapper that delegates to the guard script.
- The guard parses `flake.nix` for `./scripts/...` references, checks that each target exists and is executable, and when run in a Git checkout requires Git index mode `100755`.

## Validation

- Ran `bash -n` against the new verifier script in the local execution environment.
- Ran the verifier against a synthesized source tree containing the parsed flake references and executable script targets.
- Confirmed the branch diff is limited to `flake.nix` and `scripts/verify-flake-script-executables.sh`.

## Not run

- `nix flake check`: not run because the execution environment could not clone/fetch the repository from GitHub and does not have the repo checkout available for full Nix evaluation.
- Existing flake apps: not run for the same reason; `verify-neovim-config` also depends on `nvim` availability.

Fixes #52