### PR TITLE
Add graphical Secret Service keyring profile

### DIFF
--- a/files/home/.local/bin/dub-session-start
+++ b/files/home/.local/bin/dub-session-start
@@ -8,6 +8,23 @@ exec >>"$log_dir/session-start.log" 2>&1
 
 printf '[%s] dub-session-start\n' "$(date --iso-8601=seconds)"
 
+start_graphical_session_targets() {
+  if ! command -v systemctl >/dev/null 2>&1; then
+    printf '[skip] systemctl not found; graphical session targets unavailable\n'
+    return 0
+  fi
+
+  systemctl --user import-environment \
+    WAYLAND_DISPLAY \
+    XDG_CURRENT_DESKTOP \
+    XDG_SESSION_DESKTOP \
+    XDG_SESSION_TYPE \
+    DBUS_SESSION_BUS_ADDRESS || true
+
+  systemctl --user start graphical-session-pre.target || true
+  systemctl --user start graphical-session.target || true
+}
+
 start_once() {
   local name="$1"
   shift
@@ -24,6 +41,8 @@ start_once() {
     "$@" &
   fi
 }
+
+start_graphical_session_targets
 
 start_once waybar waybar
 start_once nm-applet nm-applet --indicator

--- a/home/ryjen/profiles/graphical.nix
+++ b/home/ryjen/profiles/graphical.nix
@@ -1,4 +1,5 @@
 { ... }:
 {
   dotfiles.host.graphical.enable = true;
+  dotfiles.graphical.keyring.enable = true;
 }

--- a/modules/home/default.nix
+++ b/modules/home/default.nix
@@ -20,6 +20,7 @@
     ./gpg.nix
     ./hypr.nix
     ./input.nix
+    ./keyring.nix
     ./lsd.nix
     ./lolcat.nix
     ./micrantha.nix

--- a/modules/home/keyring.nix
+++ b/modules/home/keyring.nix
@@ -1,0 +1,35 @@
+{
+  lib,
+  pkgs,
+  config,
+  ...
+}:
+{
+  options.dotfiles.graphical.keyring.enable = lib.mkEnableOption "graphical Secret Service credential storage";
+
+  config = lib.mkIf config.dotfiles.graphical.keyring.enable {
+    assertions = [
+      {
+        assertion = config.dotfiles.host.graphical.enable;
+        message = "dotfiles.graphical.keyring.enable requires dotfiles.host.graphical.enable.";
+      }
+      {
+        assertion = config.dotfiles.host.userSystemd.enable;
+        message = "dotfiles.graphical.keyring.enable requires Home Manager user systemd support.";
+      }
+    ];
+
+    home.packages = [
+      pkgs.gnome-keyring
+    ];
+
+    services.gnome-keyring = {
+      enable = true;
+      components = [
+        "pkcs11"
+        "secrets"
+        "ssh"
+      ];
+    };
+  };
+}

--- a/modules/home/keyring.nix
+++ b/modules/home/keyring.nix
@@ -26,9 +26,7 @@
     services.gnome-keyring = {
       enable = true;
       components = [
-        "pkcs11"
         "secrets"
-        "ssh"
       ];
     };
   };


### PR DESCRIPTION
## Summary

- add a graphical `dotfiles.graphical.keyring.enable` Home Manager capability
- wire the capability to `services.gnome-keyring` with Secret Service support only
- enable the capability through the shared graphical profile used by `dubnium` and `technetium`
- start Home Manager graphical session targets from the managed Hyprland session startup script

## Scope notes

- credential storage remains a generic graphical-session capability, not an Android Studio-specific dependency
- GNOME Keyring is limited to the `secrets` component to avoid taking over SSH agent or PKCS#11 behavior in this slice
- `headless` and `wsl` stay on the lightweight module set and do not import or enable the graphical keyring module
- system/PAM prerequisites remain owned by `dubnium` issue #132

## Validation

- inspected the current host layering: `dubnium` and `technetium` import `./layers/graphical.nix`; `headless` and `wsl` import `./layers/lightweight.nix`
- inspected the branch contents after writes
- reviewed the session startup path so `graphical-session-pre.target` / `graphical-session.target` are started before graphical apps
- not run locally: this environment cannot clone GitHub or evaluate the flake with Nix

Closes #48