### PR TITLE
Enable Hermes for workstation profiles

### DIFF
--- a/home/ryjen/profiles/nixos.nix
+++ b/home/ryjen/profiles/nixos.nix
@@ -5,7 +5,6 @@
   ];
 
   dotfiles.host.name = "nixos";
-  dotfiles.agents.hermes.enable = true;
   dotfiles.profiles.android.enable = true;
   dotfiles.profiles.micrantha.enable = true;
   dotfiles.hypr.adoptedProfile = "dubnium";

--- a/home/ryjen/profiles/workstation.nix
+++ b/home/ryjen/profiles/workstation.nix
@@ -5,5 +5,7 @@
   ];
 
   dotfiles.host.role = "workstation";
+  dotfiles.host.graphical.enable = true;
   dotfiles.profiles.workstation.enable = true;
+  dotfiles.agents.hermes.enable = true;
 }

--- a/home/ryjen/profiles/workstation.nix
+++ b/home/ryjen/profiles/workstation.nix
@@ -5,7 +5,6 @@
   ];
 
   dotfiles.host.role = "workstation";
-  dotfiles.host.graphical.enable = true;
   dotfiles.profiles.workstation.enable = true;
   dotfiles.agents.hermes.enable = true;
 }


### PR DESCRIPTION
## Summary

- enable `dotfiles.agents.hermes` from the shared `workstation` profile
- remove the duplicate Hermes toggle from the legacy `nixos` profile
- keeps Hermes available for `ryjen@nixos`, while also enabling it for named workstation profiles such as `ryjen@dubnium` and `ryjen@technetium`

## Similar-profile check

Reviewed the other explicit profile toggles that could have been affected by the host split:

- `dotfiles.profiles.browser.enable`: already enabled on both `dubnium` and `technetium`
- `dotfiles.profiles.android.enable`: still only enabled on legacy `nixos`; named hosts explicitly disable it, so this PR leaves that policy unchanged
- `dotfiles.profiles.micrantha.enable`: still only enabled on legacy `nixos`; named hosts explicitly disable it, so this PR leaves that policy unchanged
- `dotfiles.npm.enable`: defaults from `dotfiles.profiles.workstation.enable`, so no host-specific fix needed

## Validation

- inspected profile imports and module enable gates through GitHub connector
- compared branch against `main`: two profile files changed only
- not run locally in a Nix evaluator from this connector session