### PR TITLE
[codex] Disable zsh extended glob

### DIFF
--- a/modules/home/zsh.nix
+++ b/modules/home/zsh.nix
@@ -42,7 +42,7 @@
       # options
       setopt globdots
       setopt auto_cd
-      setopt extended_glob
+      unsetopt extended_glob
       setopt hist_ignore_all_dups
       setopt hist_reduce_blanks
       setopt hist_verify


### PR DESCRIPTION
## Summary

- Disable zsh `EXTENDED_GLOB` in the Home Manager zsh module.
- This stops `#` from acting as an extended glob repetition operator in interactive shells.

## Notes

The change is intentionally scoped to `modules/home/zsh.nix` and leaves other glob options such as `globdots` and `no_case_glob` unchanged.

## Validation

- Inspected the zsh Home Manager module.
- Confirmed the managed shell options previously enabled `setopt extended_glob`.
