### PR TITLE
Normalize GTK and Hyprland cursor theme

### DIFF
--- a/files/home/.config/hypr/custom.d/cursor.conf
+++ b/files/home/.config/hypr/custom.d/cursor.conf
@@ -1,0 +1,8 @@
+# Keep Hyprland, GTK, and XCursor aligned.
+# This is sourced after adopted machine fragments so it wins over older host-local cursor settings.
+env = XCURSOR_THEME,Adwaita
+env = XCURSOR_SIZE,24
+
+exec-once = dbus-update-activation-environment --systemd XCURSOR_THEME XCURSOR_SIZE
+exec-once = systemctl --user import-environment XCURSOR_THEME XCURSOR_SIZE
+exec-once = hyprctl setcursor Adwaita 24

--- a/modules/home/hypr.nix
+++ b/modules/home/hypr.nix
@@ -94,6 +94,8 @@ in
       adoptedProfiles.${config.dotfiles.hypr.adoptedProfile};
     xdg.configFile."hypr/custom.d/00-empty.conf".source =
       ../../files/home/.config/hypr/custom.d/empty.conf;
+    xdg.configFile."hypr/custom.d/10-cursor.conf".source =
+      ../../files/home/.config/hypr/custom.d/cursor.conf;
     xdg.configFile."hypr/hyprpaper.conf".source = ../../files/home/.config/hypr/hyprpaper.conf;
     xdg.configFile."hyprpaper/custom.d/00-empty.conf".source =
       ../../files/home/.config/hyprpaper/custom.d/empty.conf;

--- a/modules/home/session.nix
+++ b/modules/home/session.nix
@@ -30,6 +30,20 @@
       wofi
     ];
 
+    home.pointerCursor = {
+      gtk.enable = true;
+      x11.enable = true;
+      package = pkgs.adwaita-icon-theme;
+      name = "Adwaita";
+      size = 24;
+    };
+
+    gtk.cursorTheme = {
+      package = pkgs.adwaita-icon-theme;
+      name = "Adwaita";
+      size = 24;
+    };
+
     home.sessionVariables = {
       GIT_EDITOR = "nvim";
       PAGER = "bat -p";
@@ -39,6 +53,8 @@
       MOZ_ENABLE_WAYLAND = "1";
       MOZ_DBUS_REMOTE = "1";
       GTK_CSD = "0";
+      XCURSOR_THEME = "Adwaita";
+      XCURSOR_SIZE = "24";
       QT_QPA_PLATFORM = "wayland";
       QT_QPA_PLATFORMTHEME = "qt5ct";
       QT_WAYLAND_DISABLE_WINDOWDECORATION = "1";


### PR DESCRIPTION
## Summary

- set the workstation Home Manager cursor theme to Adwaita for GTK/XCursor
- export matching `XCURSOR_THEME` / `XCURSOR_SIZE` session variables
- add a managed Hyprland custom cursor fragment sourced after adopted host fragments so stale host-local cursor settings do not win

## Why

GTK was logging missing cursor names such as `hand2` and `arrow`. The dotfiles had Hyprland host fragments setting cursor env directly, with `dubnium` still forcing `DMZ-Black`, while GTK/Home Manager did not declare a matching cursor theme. This makes the cursor selection consistent across GTK, XCursor, and Hyprland.

## Validation

- Compared branch against `main`: 3 commits, 3 changed files
- Could not run local Nix validation because the sandbox has no network access to clone the repository or evaluate the flake dependencies

## Follow-up after merge

Run the normal Home Manager activation, then restart the graphical session or run:

```bash
hyprctl reload
hyprctl setcursor Adwaita 24
systemctl --user import-environment XCURSOR_THEME XCURSOR_SIZE
```
