### PR TITLE
Fix Nix evaluation warnings

### DIFF
--- a/modules/home/agents.nix
+++ b/modules/home/agents.nix
@@ -6,7 +6,7 @@
   ...
 }:
 let
-  hermesPackage = hermes-agent.packages.${pkgs.system}.default;
+  hermesPackage = hermes-agent.packages.${pkgs.stdenv.hostPlatform.system}.default;
 in
 {
   options.dotfiles.agents.hermes.enable = lib.mkEnableOption "Hermes agent package and config";

--- a/modules/home/git.nix
+++ b/modules/home/git.nix
@@ -33,36 +33,36 @@ in
         path = "~/.config/git/conf.d/micrantha";
       }
     ];
-    aliases = {
-      ff = "flow feature";
-      wip = "!git add --all; git ci -m WIP";
-      co = "checkout";
-      blame = "blame -w -C -C -C";
-      wdiff = "diff --word-diff";
-      cob = "checkout -b";
-      last = "log -1 HEAD";
-      lbr = "for-each-ref --sort=-committerdate --format='%(refname:short)' refs/heads/ | head -n 1";
-      st = "status";
-      fpush = "push --force-with-lease";
-      stash = "stash --all";
-      save = "commit -a";
-      aliases = "config --get-regex alias";
-      loga = "log --pretty=format:'%C(yellow)%h %<(24)%C(red)%ad %<(18)%C(green)%an %C(reset)%s' --date=local --max-count=10";
-      lg = "log --graph --abbrev-commit --decorate --date=relative --all";
-      changelog = "log origin..HEAD --format='* %s%n%w(,4,4)%+b'";
-      glg = "log --oneline --decorate --all --graph";
-      undo = "reset HEAD~1 --mixed";
-      correct = "reset --hard";
-      uncommit = "reset --soft HEAD~";
-      done = "push origin HEAD";
-      unstage = "reset HEAD --";
-      del = "branch -D";
-      br = "branch --format='%(HEAD) %(color:yellow)%(refname:short)%(color:reset) - %(contents:subject) %(color:green)(%(committerdate:relative)) [%(authorname)]' --sort=-committerdate";
-      cleanup-merged = "!f(){ git fetch && git branch --merged | grep -v '* ' | xargs git branch --delete; };f";
-      amend = "commit --amend --reuse-message=HEAD";
-      fixup = "rebase -i HEAD~2";
-    };
-    extraConfig = {
+    settings = {
+      alias = {
+        ff = "flow feature";
+        wip = "!git add --all; git ci -m WIP";
+        co = "checkout";
+        blame = "blame -w -C -C -C";
+        wdiff = "diff --word-diff";
+        cob = "checkout -b";
+        last = "log -1 HEAD";
+        lbr = "for-each-ref --sort=-committerdate --format='%(refname:short)' refs/heads/ | head -n 1";
+        st = "status";
+        fpush = "push --force-with-lease";
+        stash = "stash --all";
+        save = "commit -a";
+        aliases = "config --get-regex alias";
+        loga = "log --pretty=format:'%C(yellow)%h %<(24)%C(red)%ad %<(18)%C(green)%an %C(reset)%s' --date=local --max-count=10";
+        lg = "log --graph --abbrev-commit --decorate --date=relative --all";
+        changelog = "log origin..HEAD --format='* %s%n%w(,4,4)%+b'";
+        glg = "log --oneline --decorate --all --graph";
+        undo = "reset HEAD~1 --mixed";
+        correct = "reset --hard";
+        uncommit = "reset --soft HEAD~";
+        done = "push origin HEAD";
+        unstage = "reset HEAD --";
+        del = "branch -D";
+        br = "branch --format='%(HEAD) %(color:yellow)%(refname:short)%(color:reset) - %(contents:subject) %(color:green)(%(committerdate:relative)) [%(authorname)]' --sort=-committerdate";
+        cleanup-merged = "!f(){ git fetch && git branch --merged | grep -v '* ' | xargs git branch --delete; };f";
+        amend = "commit --amend --reuse-message=HEAD";
+        fixup = "rebase -i HEAD~2";
+      };
       core.excludesfile = "~/.gitignore";
       difftool.prompt = false;
       gui.gcwarning = false;

--- a/modules/home/helix.nix
+++ b/modules/home/helix.nix
@@ -43,7 +43,7 @@
         {
           name = "nix";
           auto-format = true;
-          formatter.command = "${pkgs.nixfmt-rfc-style}/bin/nixfmt";
+          formatter.command = "${pkgs.nixfmt}/bin/nixfmt";
         }
       ];
     };
@@ -52,7 +52,7 @@
   # Extra LSPs that Helix uses
   home.packages = with pkgs; [
     nil
-    nixfmt-rfc-style
+    nixfmt
     marksman # Markdown LSP
     vscode-langservers-extracted # HTML/CSS/JSON
   ];

--- a/modules/home/neovim.nix
+++ b/modules/home/neovim.nix
@@ -8,22 +8,17 @@
     defaultEditor = true;
     viAlias = true;
     vimAlias = true;
+    withRuby = true;
+    withPython3 = true;
 
-    # External tools used by the Lua config and plugin integrations.
-    # Keep this list explicit so Neovim behavior stays reproducible under Nix.
     extraPackages = with pkgs; [
-      # Search & Navigation
       ripgrep
       fd
       fzf
-
-      # Language Servers
       lua-language-server
-      nil # Nix LSP
-      pyright # Python LSP
+      nil
+      pyright
       typescript-language-server
-
-      # Formatters & Linters
       stylua
       nixfmt-rfc-style
       black
@@ -31,16 +26,12 @@
       shfmt
       shellcheck
       prettier
-
-      # Runtime support for plugins
-      gcc # for tree-sitter and telescope-fzf-native
+      gcc
       nodejs
       git
     ];
   };
 
-  # Declaratively symlink the config from the repo into the home directory.
-  # Lua owns editor behavior; Home Manager owns installation and external tools.
   xdg.configFile."nvim" = {
     source = ../../files/home/.config/nvim;
     recursive = true;
@@ -48,10 +39,5 @@
 
   xdg.configFile."nvim/local.lua".text = ''
     -- Local Neovim configuration.
-    --
-    -- Ownership:
-    -- - machine-specific
-    -- - writable by the user
-    -- - never automatically promoted by configctl
   '';
 }

--- a/modules/home/neovim.nix
+++ b/modules/home/neovim.nix
@@ -11,27 +11,38 @@
     withRuby = true;
     withPython3 = true;
 
+    # External tools used by the Lua config and plugin integrations.
+    # Keep this list explicit so Neovim behavior stays reproducible under Nix.
     extraPackages = with pkgs; [
+      # Search & Navigation
       ripgrep
       fd
       fzf
+
+      # Language Servers
       lua-language-server
-      nil
-      pyright
+      nil # Nix LSP
+      pyright # Python LSP
       typescript-language-server
+
+      # Formatters & Linters
       stylua
-      nixfmt-rfc-style
+      nixfmt
       black
       ruff
       shfmt
       shellcheck
       prettier
-      gcc
+
+      # Runtime support for plugins
+      gcc # for tree-sitter and telescope-fzf-native
       nodejs
       git
     ];
   };
 
+  # Declaratively symlink the config from the repo into the home directory.
+  # Lua owns editor behavior; Home Manager owns installation and external tools.
   xdg.configFile."nvim" = {
     source = ../../files/home/.config/nvim;
     recursive = true;
@@ -39,5 +50,10 @@
 
   xdg.configFile."nvim/local.lua".text = ''
     -- Local Neovim configuration.
+    --
+    -- Ownership:
+    -- - machine-specific
+    -- - writable by the user
+    -- - never automatically promoted by configctl
   '';
 }

--- a/modules/home/zsh.nix
+++ b/modules/home/zsh.nix
@@ -1,15 +1,16 @@
 {
+  config,
   pkgs,
   ...
 }:
 {
   home.file.".zshenv".text = ''
-    export ZDOTDIR="$HOME/.config/zsh"
+    export ZDOTDIR="${config.xdg.configHome}/zsh"
   '';
 
   programs.zsh = {
     enable = true;
-    dotDir = ".config/zsh";
+    dotDir = "${config.xdg.configHome}/zsh";
     enableCompletion = true;
     autosuggestion.enable = true;
     syntaxHighlighting.enable = true;


### PR DESCRIPTION
## Summary

- Set Home Manager Neovim provider defaults explicitly to keep current legacy behavior:
  - `programs.neovim.withRuby = true`
  - `programs.neovim.withPython3 = true`
- Replace deprecated `nixfmt-rfc-style` references with `pkgs.nixfmt`.
- Move Git config from deprecated `programs.git.aliases` / `programs.git.extraConfig` to `programs.git.settings`.
- Use an absolute Zsh `dotDir` via `config.xdg.configHome`.
- Replace `pkgs.system` with `pkgs.stdenv.hostPlatform.system` for Hermes package lookup.

## Validation

Not run locally from this connector session.