### PR TITLE
Add C++ build tools to devtools

### DIFF
--- a/modules/home/devtools.nix
+++ b/modules/home/devtools.nix
@@ -1,10 +1,14 @@
 { pkgs, ... }:
 {
   home.packages = [
+    pkgs.cmake
     pkgs.ffmpeg
+    pkgs.gcc
     pkgs.gh
     pkgs.git
+    pkgs.gnumake
     pkgs.openssh
+    pkgs.pkg-config
     pkgs.python311
     pkgs.ripgrep
     pkgs.uv


### PR DESCRIPTION
## Summary
- add GCC/g++ via `pkgs.gcc` to the shared Home Manager devtools package set
- add common native build helpers: `cmake`, `gnumake`, and `pkg-config`

## Notes
This keeps the toolchain in `modules/home/devtools.nix`, alongside the existing general development tools, rather than making it host-specific.

## Validation
- Not run locally; connector-only change.