### PR TITLE
[codex] Add Antigravity CLI to agent tooling

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,10 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     hermes-agent.url = "github:NousResearch/hermes-agent";
+    antigravity-nix = {
+      url = "github:jacopone/antigravity-nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     sops-nix = {
       url = "github:Mic92/sops-nix";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -24,6 +28,7 @@
       nixpkgs,
       home-manager,
       hermes-agent,
+      antigravity-nix,
       sops-nix,
       git-hooks,
       ...
@@ -40,7 +45,7 @@
         home-manager.lib.homeManagerConfiguration {
           inherit pkgs;
           extraSpecialArgs = {
-            inherit self username hermes-agent;
+            inherit self username hermes-agent antigravity-nix;
           };
           modules = [
             profileModule
@@ -52,7 +57,7 @@
         nixpkgs.lib.nixosSystem {
           inherit system;
           specialArgs = {
-            inherit self username hermes-agent;
+            inherit self username hermes-agent antigravity-nix;
           };
           modules = [
             ./hosts/nixos/configuration.nix
@@ -62,20 +67,22 @@
               home-manager.useGlobalPkgs = true;
               home-manager.useUserPackages = true;
               home-manager.extraSpecialArgs = {
-                inherit self username hermes-agent;
+                inherit self username hermes-agent antigravity-nix;
               };
-              home-manager.users.${username} = {
-                imports = [
-                  profileModule
-                  sops-nix.homeManagerModules.sops
-                ];
+              home-manager.users = {
+                ryjen = {
+                  imports = [
+                    profileModule
+                    sops-nix.homeManagerModules.sops
+                  ];
+                };
               };
             }
           ];
         };
     in
     {
-      apps.${system} = {
+      apps.x86_64-linux = {
         verify-container = {
           type = "app";
           program = "${./scripts/verify-in-container.sh}";
@@ -92,7 +99,7 @@
         };
       };
 
-      checks.${system} = {
+      checks.x86_64-linux = {
         flake-script-executables =
           pkgs.runCommand "flake-script-executables" { nativeBuildInputs = [ pkgs.git ]; }
             ''
@@ -100,7 +107,7 @@
               touch "$out"
             '';
 
-        pre-commit-check = git-hooks.lib.${system}.run {
+        pre-commit-check = git-hooks.lib.x86_64-linux.run {
           src = self;
           hooks = {
             nixfmt.enable = true;
@@ -108,28 +115,28 @@
         };
       };
 
-      devShells.${system}.default =
+      devShells.x86_64-linux.default =
         let
-          inherit (self.checks.${system}.pre-commit-check) shellHook enabledPackages;
+          inherit (self.checks.x86_64-linux.pre-commit-check) shellHook enabledPackages;
         in
         pkgs.mkShell {
           inherit shellHook;
           buildInputs = enabledPackages;
         };
 
-      packages.${system} = {
-        hermes-agent = hermes-agent.packages.${system}.default;
+      packages.x86_64-linux = {
+        hermes-agent = hermes-agent.packages.x86_64-linux.default;
       };
 
       nixosConfigurations.nixos = mkNixosConfig ./home/ryjen/home.nix;
       nixosConfigurations.verify = mkNixosConfig ./home/ryjen/verify-home.nix;
 
-      homeConfigurations."${username}@nixos" = mkHomeConfig ./home/ryjen/home.nix;
-      homeConfigurations."${username}@verify" = mkHomeConfig ./home/ryjen/verify-home.nix;
-      homeConfigurations."${username}@headless" = mkHomeConfig ./home/ryjen/headless-home.nix;
-      homeConfigurations."${username}@wsl" = mkHomeConfig ./home/ryjen/wsl-home.nix;
-      homeConfigurations."${username}@dubnium" = mkHomeConfig ./home/ryjen/dubnium-home.nix;
-      homeConfigurations."${username}@technetium" = mkHomeConfig ./home/ryjen/technetium-home.nix;
+      homeConfigurations."ryjen@nixos" = mkHomeConfig ./home/ryjen/home.nix;
+      homeConfigurations."ryjen@verify" = mkHomeConfig ./home/ryjen/verify-home.nix;
+      homeConfigurations."ryjen@headless" = mkHomeConfig ./home/ryjen/headless-home.nix;
+      homeConfigurations."ryjen@wsl" = mkHomeConfig ./home/ryjen/wsl-home.nix;
+      homeConfigurations."ryjen@dubnium" = mkHomeConfig ./home/ryjen/dubnium-home.nix;
+      homeConfigurations."ryjen@technetium" = mkHomeConfig ./home/ryjen/technetium-home.nix;
 
       nixosModules.dubnium-home-manager =
         {
@@ -147,15 +154,20 @@
           home-manager.useGlobalPkgs = true;
           home-manager.useUserPackages = true;
           home-manager.extraSpecialArgs = {
-            inherit self hermes-agent;
+            inherit self hermes-agent antigravity-nix;
             username = dubniumUsername;
           };
-          home-manager.users.${dubniumUsername} = {
-            imports = [
-              ./home/ryjen/dubnium-home.nix
-              sops-nix.homeManagerModules.sops
-            ];
-          };
+          home-manager.users = builtins.listToAttrs [
+            {
+              name = dubniumUsername;
+              value = {
+                imports = [
+                  ./home/ryjen/dubnium-home.nix
+                  sops-nix.homeManagerModules.sops
+                ];
+              };
+            }
+          ];
         };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -69,20 +69,18 @@
               home-manager.extraSpecialArgs = {
                 inherit self username hermes-agent antigravity-nix;
               };
-              home-manager.users = {
-                ryjen = {
-                  imports = [
-                    profileModule
-                    sops-nix.homeManagerModules.sops
-                  ];
-                };
+              home-manager.users.${username} = {
+                imports = [
+                  profileModule
+                  sops-nix.homeManagerModules.sops
+                ];
               };
             }
           ];
         };
     in
     {
-      apps.x86_64-linux = {
+      apps.${system} = {
         verify-container = {
           type = "app";
           program = "${./scripts/verify-in-container.sh}";
@@ -99,7 +97,7 @@
         };
       };
 
-      checks.x86_64-linux = {
+      checks.${system} = {
         flake-script-executables =
           pkgs.runCommand "flake-script-executables" { nativeBuildInputs = [ pkgs.git ]; }
             ''
@@ -107,7 +105,7 @@
               touch "$out"
             '';
 
-        pre-commit-check = git-hooks.lib.x86_64-linux.run {
+        pre-commit-check = git-hooks.lib.${system}.run {
           src = self;
           hooks = {
             nixfmt.enable = true;
@@ -115,28 +113,28 @@
         };
       };
 
-      devShells.x86_64-linux.default =
+      devShells.${system}.default =
         let
-          inherit (self.checks.x86_64-linux.pre-commit-check) shellHook enabledPackages;
+          inherit (self.checks.${system}.pre-commit-check) shellHook enabledPackages;
         in
         pkgs.mkShell {
           inherit shellHook;
           buildInputs = enabledPackages;
         };
 
-      packages.x86_64-linux = {
-        hermes-agent = hermes-agent.packages.x86_64-linux.default;
+      packages.${system} = {
+        hermes-agent = hermes-agent.packages.${system}.default;
       };
 
       nixosConfigurations.nixos = mkNixosConfig ./home/ryjen/home.nix;
       nixosConfigurations.verify = mkNixosConfig ./home/ryjen/verify-home.nix;
 
-      homeConfigurations."ryjen@nixos" = mkHomeConfig ./home/ryjen/home.nix;
-      homeConfigurations."ryjen@verify" = mkHomeConfig ./home/ryjen/verify-home.nix;
-      homeConfigurations."ryjen@headless" = mkHomeConfig ./home/ryjen/headless-home.nix;
-      homeConfigurations."ryjen@wsl" = mkHomeConfig ./home/ryjen/wsl-home.nix;
-      homeConfigurations."ryjen@dubnium" = mkHomeConfig ./home/ryjen/dubnium-home.nix;
-      homeConfigurations."ryjen@technetium" = mkHomeConfig ./home/ryjen/technetium-home.nix;
+      homeConfigurations."${username}@nixos" = mkHomeConfig ./home/ryjen/home.nix;
+      homeConfigurations."${username}@verify" = mkHomeConfig ./home/ryjen/verify-home.nix;
+      homeConfigurations."${username}@headless" = mkHomeConfig ./home/ryjen/headless-home.nix;
+      homeConfigurations."${username}@wsl" = mkHomeConfig ./home/ryjen/wsl-home.nix;
+      homeConfigurations."${username}@dubnium" = mkHomeConfig ./home/ryjen/dubnium-home.nix;
+      homeConfigurations."${username}@technetium" = mkHomeConfig ./home/ryjen/technetium-home.nix;
 
       nixosModules.dubnium-home-manager =
         {
@@ -157,17 +155,12 @@
             inherit self hermes-agent antigravity-nix;
             username = dubniumUsername;
           };
-          home-manager.users = builtins.listToAttrs [
-            {
-              name = dubniumUsername;
-              value = {
-                imports = [
-                  ./home/ryjen/dubnium-home.nix
-                  sops-nix.homeManagerModules.sops
-                ];
-              };
-            }
-          ];
+          home-manager.users.${dubniumUsername} = {
+            imports = [
+              ./home/ryjen/dubnium-home.nix
+              sops-nix.homeManagerModules.sops
+            ];
+          };
         };
     };
 }

--- a/home/ryjen/profiles/workstation.nix
+++ b/home/ryjen/profiles/workstation.nix
@@ -7,4 +7,5 @@
   dotfiles.host.role = "workstation";
   dotfiles.profiles.workstation.enable = true;
   dotfiles.agents.hermes.enable = true;
+  dotfiles.agents.antigravity.enable = true;
 }

--- a/modules/home/agents.nix
+++ b/modules/home/agents.nix
@@ -1,4 +1,5 @@
 {
+  antigravity-nix,
   hermes-agent,
   lib,
   pkgs,
@@ -6,15 +7,32 @@
   ...
 }:
 let
-  hermesPackage = hermes-agent.packages.${pkgs.stdenv.hostPlatform.system}.default;
+  system = pkgs.stdenv.hostPlatform.system;
+  hermesPackage = hermes-agent.packages.${system}.default;
+  antigravityPackage = antigravity-nix.packages.${system}.google-antigravity-cli;
+  cfg = config.dotfiles.agents;
 in
 {
-  options.dotfiles.agents.hermes.enable = lib.mkEnableOption "Hermes agent package and config";
+  options.dotfiles.agents = {
+    hermes.enable = lib.mkEnableOption "Hermes agent package and config";
+
+    antigravity = {
+      enable = lib.mkEnableOption "Google Antigravity CLI";
+
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = antigravityPackage;
+        description = "Google Antigravity CLI package to install.";
+      };
+    };
+  };
 
   config = {
-    home.packages = lib.optional config.dotfiles.agents.hermes.enable hermesPackage;
+    home.packages =
+      lib.optional cfg.hermes.enable hermesPackage
+      ++ lib.optional cfg.antigravity.enable cfg.antigravity.package;
 
-    home.file.".hermes/config.yaml" = lib.mkIf config.dotfiles.agents.hermes.enable {
+    home.file.".hermes/config.yaml" = lib.mkIf cfg.hermes.enable {
       source = ../../files/home/.hermes/config.yaml;
     };
 


### PR DESCRIPTION
## Summary

- Add the `jacopone/antigravity-nix` flake input and pass it to Home Manager modules.
- Extend `modules/home/agents.nix` with `dotfiles.agents.antigravity` package options.
- Enable Antigravity for the shared workstation profile alongside Hermes.

## Notes

Antigravity is treated as agent tooling rather than generic dev tooling, so the option lives under `dotfiles.agents.*` instead of `modules/home/devtools.nix` or `nix/home/ai`.

`flake.lock` is not updated in this PR because this connector environment does not have `nix` available to resolve and write the lock entry. Run this locally before merge:

```bash
nix flake lock --update-input antigravity-nix
nix flake check --no-build
home-manager switch --flake .#ryjen@dubnium
command -v agy
agy --version
```

## Validation

- Inspected the active `ryjen@dubnium` Home Manager path.
- Confirmed the diff is limited to flake wiring, the agents module, and workstation profile enablement.
- Not run locally: no `nix` binary available in this execution environment.