### PR TITLE
fix(neovim): migrate none-ls external builtins

### DIFF
--- a/files/home/.config/nvim/lua/plugins.lua
+++ b/files/home/.config/nvim/lua/plugins.lua
@@ -22,7 +22,14 @@ require("lazy").setup({
 			"hrsh7th/cmp-nvim-lsp",
 		},
 	},
-	{ "nvimtools/none-ls.nvim", dependencies = { "nvim-lua/plenary.nvim" } },
+	{
+		"nvimtools/none-ls.nvim",
+		dependencies = {
+			"nvim-lua/plenary.nvim",
+			"nvimtools/none-ls-extras.nvim",
+			"gbprod/none-ls-shellcheck.nvim",
+		},
+	},
 
 	"fidian/hexmode",
 

--- a/files/home/.config/nvim/plugin/lsp.lua
+++ b/files/home/.config/nvim/plugin/lsp.lua
@@ -147,6 +147,17 @@ configure_lsp("nil_ls", {})
 configure_lsp("pyright", {})
 configure_lsp("ts_ls", {})
 
+vim.api.nvim_create_autocmd("BufWritePre", {
+	group = vim.api.nvim_create_augroup("dotfiles_trim_whitespace", { clear = true }),
+	pattern = "*",
+	callback = function()
+		local save = vim.fn.winsaveview()
+		vim.cmd([[%s/\s\+$//e]])
+		vim.cmd([[%s#\($\n\s*\)\+\%$##e]])
+		vim.fn.winrestview(save)
+	end,
+})
+
 local null_ls = optional_require("null-ls")
 if null_ls then
 	local sources = {}
@@ -157,18 +168,17 @@ if null_ls then
 	end
 
 	local formatting = null_ls.builtins.formatting
-	local diagnostics = null_ls.builtins.diagnostics
 
 	add(formatting.stylua)
 	add(formatting.nixfmt)
 	add(formatting.black)
 	add(formatting.shfmt)
 	add(formatting.prettier)
-	add(formatting.trim_whitespace)
-	add(formatting.trim_newlines)
 
-	add(diagnostics.ruff)
-	add(diagnostics.shellcheck)
+	add(optional_require("none-ls.formatting.ruff"))
+	add(optional_require("none-ls.diagnostics.ruff"))
+	add(optional_require("none-ls-shellcheck.diagnostics"))
+	add(optional_require("none-ls-shellcheck.code_actions"))
 
 	null_ls.setup({
 		sources = sources,


### PR DESCRIPTION
## Summary

- Add `none-ls-extras.nvim` and `none-ls-shellcheck.nvim` as `none-ls` dependencies.
- Stop referencing stale core `none-ls` builtins for `ruff`, `shellcheck`, `trim_whitespace`, and `trim_newlines`.
- Move whitespace/newline trimming to a native `BufWritePre` autocmd.

## Validation

- Inspected the updated files through the GitHub connector.
- Could not run local Neovim/Nix checks in this environment because the repository is not locally available and outbound `git clone` is unavailable.