### PR TITLE
feat(configctl): add dotfiles init contract verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@
 - `nix build .#homeConfigurations.USERNAME@verify.activationPackage` - build the lightweight verification Home Manager activation.
 - `nix build .#nixosConfigurations.verify.config.system.build.toplevel` - build the lightweight verification NixOS system derivation.
 - `nix run .#verify-container` - verify flake and build targets in an isolated container.
+- `nix run .#verify-configctl-contracts` - validate dotfiles-owned `configctl` init contracts.
 
 ## Coding Style & Naming Conventions
 
@@ -56,7 +57,8 @@ This repo maintains the following agent skills under `agents/skills/`:
 - **`multi-agent-worktrees`** (`agents/skills/multi-agent-worktrees/`): Extends standard worktree isolation with multi-agent session detection, `<agent-id>-<branch>` naming, sentinel-based status/ heartbeat tracking, and staleness detection. Use this skill when working on repos shared by multiple agents or sessions. The init contract at `contracts/configctl/init/multi-agent-worktrees.toml` describes the deployment target (`~/.agents/skills/multi-agent-worktrees/`).
 
 To deploy a skill to `~/.agents/skills/`:
-  ```bash
-  configctl init multi-agent-worktrees  # when handler exists
-  # or manually: cp -r agents/skills/<name> ~/.agents/skills/
-  ```
+
+```bash
+configctl init apply multi-agent-worktrees  # when handler exists
+# or manually: cp -r agents/skills/<name> ~/.agents/skills/
+```

--- a/contracts/configctl/README.md
+++ b/contracts/configctl/README.md
@@ -2,7 +2,7 @@
 
 This directory is the dotfiles-owned contract surface consumed by Dubnium's `configctl` executor.
 
-The manifests are declarative policy. They describe what this repository owns, which user paths are intentionally local-only, and which files may be adopted or composed by explicit tooling. They do not include shell hooks, network fetches, package installation, or implicit user-state changes.
+The manifests are declarative policy. They describe what this repository owns, which user paths are intentionally local-only, and which files or mutable user-state workflows may be adopted, validated, planned, or initialized by explicit tooling. They do not include shell hooks, secrets, implicit Home Manager mutation, or automatic package installation.
 
 ## Contract roots
 
@@ -13,16 +13,27 @@ contracts/configctl/
 └── schema-v1.md
 ```
 
+Home Manager materializes init contracts to:
+
+```text
+$XDG_CONFIG_HOME/configctl/init.d/*.toml
+```
+
+This matches the Dubnium `configctl init` discovery path.
+
 ## Rules
 
-- Dotfiles owns manifests for user-owned app configuration.
-- Dubnium owns the executor implementation and validation UX.
-- Home Manager may create deterministic source/generated files, but it must not create or overwrite `local.*` escape hatches.
+- Dotfiles owns manifests for user-owned app configuration and user-layer initial-state contracts.
+- Dubnium owns executor implementation, contract parsing, risk gates, diagnostics, apply behavior, and runtime state.
+- Home Manager may create deterministic source/generated files, package manifests, PATH entries, and safe directories.
+- Home Manager must not run network-backed installs during activation.
+- Home Manager must not create or overwrite `local.*` escape hatches.
 - `local.*` paths are never promotion candidates.
 - `custom.d/*` paths are promotion candidates only through an explicit adopt workflow.
 - `adopted.d/*` paths are archive/evidence paths, ignored during normal runtime unless a manifest says otherwise.
 - Hashes are evidence for review and reconciliation. They are not authority to silently rewrite or delete user files.
 - V1 manifests must not include arbitrary shell hooks.
+- Secrets, tokens, session files, caches, and generated runtime state do not belong in repo-managed contracts.
 
 ## Optimized path model
 
@@ -49,10 +60,11 @@ Every app/init manifest must declare whether it describes current behavior or a 
 | Field | Meaning |
 | --- | --- |
 | `status` | `active` or `planned`. |
-| `current_runtime_owner` | Current writer of runtime outputs, usually `home-manager` today. |
+| `current_runtime_owner` | Current writer of runtime outputs or mutable state, usually `home-manager` today. |
 | `target_runtime_owner` | Intended future writer after migration. |
 | `executor_may_validate` | Whether `configctl` may validate the contract now. |
 | `executor_may_adopt` | Whether `configctl` may use the adoption policy now. |
+| `executor_may_initialize` | Whether `configctl` may initialize mutable user state now. |
 | `executor_may_write_outputs` | Whether `configctl` may write runtime outputs now. |
 
 Planned compose manifests are intentionally not write-enabled while Home Manager still owns the runtime files.
@@ -67,15 +79,15 @@ Files under `apps/` describe application configuration that dotfiles owns or exp
 
 ### Init manifests
 
-Files under `init/` describe initial mutable state that may be created by an explicit `configctl init <tool>` flow.
+Files under `init/` describe initial mutable state that may be created by an explicit `configctl init apply <contract>` flow.
 
 Important constraints:
 
-- Init is for first-run mutable tool state only.
-- Init may create directories and empty files with safe permissions.
+- Init is for first-run or repairable mutable user state only.
+- Init may fetch or mutate only when the contract declares the required risks and the executor receives explicit approval.
 - Init must not use arbitrary shell hooks.
-- Init must not fetch network resources.
-- Init must not prune or rewrite existing user content unless the manifest explicitly marks the action as non-destructive and the executor confirms it.
+- Init must not run from Home Manager activation.
+- Init must not prune or rewrite existing user content unless a future contract and command explicitly mark the action as destructive and the executor confirms it.
 
 ## Current coverage
 
@@ -87,12 +99,30 @@ Important constraints:
 | Mako | `apps/mako.toml` | compose | planned | Home Manager | configctl |
 | Eww | `apps/eww.toml` | compose | planned | Home Manager | configctl |
 | Waybar | `apps/waybar.toml` | compose | planned | Home Manager | configctl |
+| npm globals | `init/npm-globals.toml` | init | active | explicit user state | configctl init |
 | Variety | `init/variety.toml` | init | planned | Home Manager activation | configctl init |
+| Multi-agent worktrees skill | `init/multi-agent-worktrees.toml` | init | active, validate-only | dotfiles/manual copy | configctl init |
+
+## Verification
+
+Run the repo-side verifier directly:
+
+```sh
+nix run .#verify-configctl-contracts
+```
+
+Or as part of flake checks:
+
+```sh
+nix flake check --no-build
+```
+
+The verifier checks that init contracts are valid TOML, use supported risk labels, have unique IDs, and that enabled contracts have dotfiles-side validation rules. For `npm-globals`, it also verifies that the contract paths match the Home Manager npm prefix and that the referenced package manifest exists.
 
 ## Non-goals
 
 - No `configctl` executable implementation in this repository.
-- No npm global package management.
-- No network-backed init.
+- No automatic npm global package management from Home Manager activation.
+- No implicit network-backed init.
 - No automatic promotion, pruning, or garbage collection.
 - No public mdBook generation.

--- a/contracts/configctl/README.md
+++ b/contracts/configctl/README.md
@@ -55,7 +55,7 @@ Behavior sections refer to roles, not duplicated path globs. For example, adopti
 
 ## Lifecycle fields
 
-Every app/init manifest must declare whether it describes current behavior or a planned migration:
+App manifests and migration-oriented init manifests may declare lifecycle fields to make current ownership and target ownership explicit:
 
 | Field | Meaning |
 | --- | --- |
@@ -66,6 +66,8 @@ Every app/init manifest must declare whether it describes current behavior or a 
 | `executor_may_adopt` | Whether `configctl` may use the adoption policy now. |
 | `executor_may_initialize` | Whether `configctl` may initialize mutable user state now. |
 | `executor_may_write_outputs` | Whether `configctl` may write runtime outputs now. |
+
+These lifecycle fields are policy metadata for ownership transitions; they are not required by the Dubnium v1 `configctl init` schema unless a typed contract or repo-side verifier requires them.
 
 Planned compose manifests are intentionally not write-enabled while Home Manager still owns the runtime files.
 
@@ -111,10 +113,10 @@ Run the repo-side verifier directly:
 nix run .#verify-configctl-contracts
 ```
 
-Or as part of flake checks:
+Or build the check derivation explicitly:
 
 ```sh
-nix flake check --no-build
+nix build .#checks.x86_64-linux.configctl-contracts
 ```
 
 The verifier checks that init contracts are valid TOML, use supported risk labels, have unique IDs, and that enabled contracts have dotfiles-side validation rules. For `npm-globals`, it also verifies that the contract paths match the Home Manager npm prefix and that the referenced package manifest exists.

--- a/contracts/configctl/init/npm-globals.toml
+++ b/contracts/configctl/init/npm-globals.toml
@@ -1,8 +1,20 @@
 schemaVersion = 1
 id = "npm-globals"
 kind = "npm-globals"
+description = "Install npm globals declared by dotfiles"
 enabled = true
 risk = ["network", "mutable-user-state"]
+tags = ["npm", "codex", "workstation"]
+
 manifest = "$HOME/.config/npm/global-packages.txt"
-prefix = "$XDG_DATA_HOME/npm"
-bin = "$XDG_DATA_HOME/npm/bin"
+prefix = "$HOME/.local/share/npm"
+bin = "$HOME/.local/share/npm/bin"
+
+[state]
+trackDesiredHash = true
+trackObservedHash = true
+
+[behavior]
+install = true
+update = false
+prune = false

--- a/contracts/configctl/schema-v1.md
+++ b/contracts/configctl/schema-v1.md
@@ -2,15 +2,161 @@
 
 This schema documents the declarative contract format under `contracts/configctl/`.
 
-The schema is intentionally small. It avoids duplicated path lists by defining path roles once in `[layout]` and referencing those roles from behavior sections.
+Dotfiles owns contract source files and static package manifests. Dubnium `configctl` owns contract discovery, runtime validation, planning, apply behavior, risk gating, and state files.
 
-## App manifest
+## Discovery
+
+Init contracts are materialized by Home Manager to:
+
+```text
+$XDG_CONFIG_HOME/configctl/init.d/*.toml
+```
+
+Default path:
+
+```text
+~/.config/configctl/init.d/*.toml
+```
+
+Runtime state belongs to Dubnium `configctl` under:
+
+```text
+$XDG_STATE_HOME/configctl/init/<id>/state.json
+```
+
+Default path:
+
+```text
+~/.local/state/configctl/init/<id>/state.json
+```
+
+## Init manifest
 
 Required top-level fields:
 
 | Field | Allowed values | Notes |
 | --- | --- | --- |
-| `schema_version` | `1` | Integer schema version. |
+| `schemaVersion` | `1` | Integer schema version. |
+| `id` | string | Stable unique contract ID. |
+| `kind` | string | Typed handler name, for example `npm-globals`. |
+| `enabled` | boolean | Whether the contract participates in normal operations. |
+| `risk` | array of strings | Risks that must be explicitly approved for mutating operations. |
+
+Optional top-level fields:
+
+| Field | Notes |
+| --- | --- |
+| `description` | Human-readable purpose. |
+| `tags` | Optional grouping or filter labels. |
+| `profile` | Optional profile selector, for example `dubnium` or `workstation`. |
+| `dependsOn` | Other contract IDs that should be applied first. |
+
+Supported risk labels:
+
+| Risk | Meaning |
+| --- | --- |
+| `network` | May fetch from a remote registry or service. |
+| `mutable-user-state` | Mutates files outside the Nix store in `$HOME`. |
+| `auth-required` | May require an existing login, token, or local session. |
+| `destructive` | May delete or prune state. |
+| `arbitrary-code` | Executes contract-provided shell or code. |
+| `privileged` | Requires elevated privileges. Avoid for user-layer contracts. |
+
+V1 dotfiles init contracts must not contain arbitrary shell hooks, auth tokens, private registry credentials, session files, caches, or generated runtime state.
+
+## Environment expansion
+
+Path fields may use only variables supported by Dubnium `configctl`:
+
+```text
+$HOME
+$XDG_CONFIG_HOME
+$XDG_STATE_HOME
+$XDG_DATA_HOME
+$XDG_CACHE_HOME
+```
+
+Rules:
+
+- Expansion is performed by `configctl`, not the shell.
+- Unknown variables are errors.
+- `~` expands to `$HOME`.
+- No command substitution.
+- No shell glob expansion.
+
+Prefer `$HOME` for paths that must match Home Manager defaults exactly.
+
+## `npm-globals` init contract
+
+`npm-globals` declares user-layer npm global tools managed by an explicit `configctl init apply` operation.
+
+Required fields:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `manifest` | path string | Package manifest path. |
+| `prefix` | path string | Expected npm global prefix. |
+| `bin` | path string | Expected npm global bin path. |
+
+Required risks:
+
+```toml
+risk = ["network", "mutable-user-state"]
+```
+
+Required state tracking:
+
+```toml
+[state]
+trackDesiredHash = true
+trackObservedHash = true
+```
+
+Required default behavior:
+
+```toml
+[behavior]
+install = true
+update = false
+prune = false
+```
+
+Normal apply must not prune undeclared packages. Any future destructive cleanup must use a separate destructive command and require explicit destructive risk approval.
+
+Example:
+
+```toml
+schemaVersion = 1
+id = "npm-globals"
+kind = "npm-globals"
+description = "Install npm globals declared by dotfiles"
+enabled = true
+risk = ["network", "mutable-user-state"]
+tags = ["npm", "codex", "workstation"]
+
+manifest = "$HOME/.config/npm/global-packages.txt"
+prefix = "$HOME/.local/share/npm"
+bin = "$HOME/.local/share/npm/bin"
+
+[state]
+trackDesiredHash = true
+trackObservedHash = true
+
+[behavior]
+install = true
+update = false
+prune = false
+```
+
+## App manifest
+
+App manifests are a dotfiles-side ownership and composition policy surface for `configctl adopt`, `status`, `doctor`, `promote`, and future compose workflows.
+
+Required top-level fields:
+
+| Field | Allowed values | Notes |
+| --- | --- | --- |
+| `schema_version` | `1` | Integer schema version for app manifests. |
 | `tool` | string | Stable tool identifier. |
 | `owner` | `dotfiles` | Policy owner for this repository. |
 | `profile` | string | Profile that activates the contract. |
@@ -93,31 +239,3 @@ executor_may_write_outputs = false
 | --- | --- |
 | `must_not_manage` | Layout roles that Home Manager or configctl must not own as generated files. |
 | `must_exist_or_be_creatable` | Layout roles whose parent directories may be created safely. |
-
-## Init manifest
-
-Required top-level fields:
-
-| Field | Allowed values | Notes |
-| --- | --- | --- |
-| `schema_version` | `1` | Integer schema version. |
-| `tool` | string | Stable tool identifier. |
-| `owner` | `dotfiles` | Policy owner. |
-| `profile` | string | Profile that activates the contract. |
-| `kind` | `initial-mutable-state` | Init contract kind. |
-| `status` | `active`, `planned` | Whether executor ownership is current. |
-| `current_runtime_owner` | string | Current owner of the mutable state behavior. |
-| `target_runtime_owner` | string | Target owner after migration. |
-| `executor_may_validate` | boolean | Whether validation is allowed now. |
-| `executor_may_initialize` | boolean | Whether init mutation is allowed now. |
-
-Required safety flags:
-
-| Field | Required value for v1 |
-| --- | --- |
-| `network` | `false` |
-| `arbitrary_commands` | `false` |
-| `destructive` | `false` |
-| `dry_run_required` | `true` |
-
-Init manifests may contain `directories`, `files`, and `settings` arrays. Those entries must be declarative and non-destructive.

--- a/docs/user-tool-state.md
+++ b/docs/user-tool-state.md
@@ -18,6 +18,7 @@ Home Manager should own:
 - PATH entries
 - durable profile/module enablement
 - directories needed for declared user tooling
+- contract manifests under `$XDG_CONFIG_HOME/configctl/init.d/`
 
 Home Manager should not own:
 
@@ -36,6 +37,22 @@ Examples:
 - npm globals: `files/home/.config/npm/global-packages.txt`
 
 Manifests describe desired durable tools. They do not imply that Home Manager should run network-backed installation during activation.
+
+## Configctl init contracts
+
+Dotfiles-owned init contracts live under:
+
+```text
+contracts/configctl/init/*.toml
+```
+
+Home Manager materializes them to the Dubnium discovery path:
+
+```text
+~/.config/configctl/init.d/*.toml
+```
+
+`configctl` owns runtime parsing, risk gates, planning, application, verification, and state under `$XDG_STATE_HOME`.
 
 ## Local experiments and promotion
 
@@ -65,6 +82,7 @@ Dotfiles owns the stable npm global environment:
 - a user-writable npm prefix
 - the npm global bin PATH entry
 - a repo-managed package manifest
+- a `configctl init` contract describing explicit mutable reconciliation
 
 Mutable npm package installation is explicit user state. It is not run by Home Manager activation.
 
@@ -75,6 +93,7 @@ Home Manager writes:
 ```text
 ~/.npmrc
 ~/.config/npm/global-packages.txt
+~/.config/configctl/init.d/npm-globals.toml
 ```
 
 The default prefix is:
@@ -118,10 +137,13 @@ files/home/.config/npm/global-packages.txt
 
 The manifest supports blank lines and `#` comments.
 
-Codex is npm-owned in this repository, so the manifest declares:
+Current durable npm globals include Codex and other npm-owned CLI tools:
 
 ```text
 @openai/codex
+@bitwarden/cli
+@tobilu/qmd
+opencode-ai
 ```
 
 Do not add npm authentication, registry credentials, or machine-local settings to managed files.
@@ -136,7 +158,7 @@ npm install -g some-tool
 
 That package remains local-only drift until it is intentionally promoted.
 
-Once Dubnium `configctl init` support is available, inspect npm global drift with:
+Inspect npm global drift with:
 
 ```sh
 configctl init status npm-globals
@@ -156,11 +178,11 @@ To make an experimental package durable:
 2. Check for binary-name conflicts with Nix packages.
 3. Add the package spec to `files/home/.config/npm/global-packages.txt`.
 4. Commit the manifest change.
-5. Reconcile with `configctl init` once available.
+5. Reconcile with `configctl init`.
 
 ```sh
 configctl init plan npm-globals
-configctl init apply npm-globals --allow network,mutable-user-state
+configctl init apply npm-globals --allow network,mutable-user-state --yes
 configctl init verify npm-globals
 ```
 
@@ -178,3 +200,12 @@ command -v codex
 ```
 
 Avoid `sudo npm install -g`. The configured prefix is user-writable by design.
+
+## Verification
+
+Run repo-side contract validation after editing init contracts or package manifests:
+
+```sh
+nix run .#verify-configctl-contracts
+nix flake check --no-build
+```

--- a/docs/user-tool-state.md
+++ b/docs/user-tool-state.md
@@ -207,5 +207,5 @@ Run repo-side contract validation after editing init contracts or package manife
 
 ```sh
 nix run .#verify-configctl-contracts
-nix flake check --no-build
+nix build .#checks.x86_64-linux.configctl-contracts
 ```

--- a/flake.nix
+++ b/flake.nix
@@ -110,6 +110,13 @@
           type = "app";
           program = "${./scripts/verify-neovim-config.sh}";
         };
+
+        verify-configctl-contracts = {
+          type = "app";
+          program = "${pkgs.writeShellScript "verify-configctl-contracts" ''
+            exec ${pkgs.python3}/bin/python3 ${./scripts/verify-configctl-contracts.py}
+          ''}";
+        };
       };
 
       checks.${system} = {
@@ -119,6 +126,11 @@
               ${./scripts/verify-flake-script-executables.sh} ${self}
               touch "$out"
             '';
+
+        configctl-contracts = pkgs.runCommand "configctl-contracts" { nativeBuildInputs = [ pkgs.python3 ]; } ''
+          python3 ${./scripts/verify-configctl-contracts.py}
+          touch "$out"
+        '';
 
         pre-commit-check = git-hooks.lib.${system}.run {
           src = self;

--- a/flake.nix
+++ b/flake.nix
@@ -114,7 +114,7 @@
         verify-configctl-contracts = {
           type = "app";
           program = "${pkgs.writeShellScript "verify-configctl-contracts" ''
-            exec ${pkgs.python3}/bin/python3 ${./scripts/verify-configctl-contracts.py}
+            exec ${pkgs.python3}/bin/python3 ${./scripts/verify-configctl-contracts.py} ${self}
           ''}";
         };
       };
@@ -128,7 +128,7 @@
             '';
 
         configctl-contracts = pkgs.runCommand "configctl-contracts" { nativeBuildInputs = [ pkgs.python3 ]; } ''
-          python3 ${./scripts/verify-configctl-contracts.py}
+          python3 ${./scripts/verify-configctl-contracts.py} ${self}
           touch "$out"
         '';
 

--- a/scripts/verify-configctl-contracts.py
+++ b/scripts/verify-configctl-contracts.py
@@ -12,7 +12,16 @@ import tomllib
 from pathlib import Path
 from typing import Any
 
-ROOT = Path(__file__).resolve().parents[1]
+
+def repo_root() -> Path:
+    if len(sys.argv) > 2:
+        fail("usage: verify-configctl-contracts.py [repo-root]")
+    if len(sys.argv) == 2:
+        return Path(sys.argv[1]).resolve()
+    return Path.cwd().resolve()
+
+
+ROOT = repo_root()
 INIT_DIR = ROOT / "contracts" / "configctl" / "init"
 FILES_HOME = ROOT / "files" / "home"
 

--- a/scripts/verify-configctl-contracts.py
+++ b/scripts/verify-configctl-contracts.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Validate dotfiles-owned configctl contract manifests.
+
+This intentionally validates the repository contract surface only. The Dubnium
+`configctl` executor owns runtime status, planning, apply, and verification.
+"""
+
+from __future__ import annotations
+
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+INIT_DIR = ROOT / "contracts" / "configctl" / "init"
+FILES_HOME = ROOT / "files" / "home"
+
+SUPPORTED_RISKS = {
+    "network",
+    "mutable-user-state",
+    "auth-required",
+    "destructive",
+    "arbitrary-code",
+    "privileged",
+}
+
+SUPPORTED_ACTIVE_KINDS = {
+    "npm-globals",
+}
+
+
+def fail(message: str) -> None:
+    print(f"configctl-contracts: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def require_type(contract: dict[str, Any], path: Path, key: str, expected: type) -> Any:
+    if key not in contract:
+        fail(f"{path}: missing required field {key!r}")
+    value = contract[key]
+    if not isinstance(value, expected):
+        fail(f"{path}: field {key!r} must be {expected.__name__}")
+    return value
+
+
+def managed_home_path(value: str) -> Path | None:
+    if value.startswith("$HOME/"):
+        return FILES_HOME / value.removeprefix("$HOME/")
+    if value.startswith("~/"):
+        return FILES_HOME / value.removeprefix("~/")
+    return None
+
+
+def validate_common(path: Path, contract: dict[str, Any], seen_ids: set[str]) -> tuple[str, str, bool]:
+    schema_version = require_type(contract, path, "schemaVersion", int)
+    if schema_version != 1:
+        fail(f"{path}: unsupported schemaVersion {schema_version!r}")
+
+    contract_id = require_type(contract, path, "id", str)
+    if not contract_id:
+        fail(f"{path}: id must not be empty")
+    if contract_id in seen_ids:
+        fail(f"{path}: duplicate contract id {contract_id!r}")
+    seen_ids.add(contract_id)
+
+    kind = require_type(contract, path, "kind", str)
+    enabled = require_type(contract, path, "enabled", bool)
+    risks = require_type(contract, path, "risk", list)
+    if not all(isinstance(risk, str) for risk in risks):
+        fail(f"{path}: risk entries must be strings")
+    unknown_risks = sorted(set(risks) - SUPPORTED_RISKS)
+    if unknown_risks:
+        fail(f"{path}: unsupported risk labels: {', '.join(unknown_risks)}")
+
+    if enabled and kind not in SUPPORTED_ACTIVE_KINDS:
+        fail(
+            f"{path}: enabled init contract kind {kind!r} has no active dotfiles validation rule"
+        )
+
+    return contract_id, kind, enabled
+
+
+def validate_npm_globals(path: Path, contract: dict[str, Any]) -> None:
+    manifest = require_type(contract, path, "manifest", str)
+    prefix = require_type(contract, path, "prefix", str)
+    bin_path = require_type(contract, path, "bin", str)
+
+    expected_prefix = "$HOME/.local/share/npm"
+    expected_bin = "$HOME/.local/share/npm/bin"
+    if prefix != expected_prefix:
+        fail(f"{path}: prefix must match Home Manager npm prefix {expected_prefix!r}")
+    if bin_path != expected_bin:
+        fail(f"{path}: bin must match Home Manager npm bin path {expected_bin!r}")
+
+    source_manifest = managed_home_path(manifest)
+    if source_manifest is None:
+        fail(f"{path}: manifest must be a managed $HOME-relative path")
+    if not source_manifest.is_file():
+        fail(f"{path}: referenced manifest does not exist: {source_manifest.relative_to(ROOT)}")
+
+    state = contract.get("state")
+    if not isinstance(state, dict):
+        fail(f"{path}: missing [state] table")
+    for key in ("trackDesiredHash", "trackObservedHash"):
+        if state.get(key) is not True:
+            fail(f"{path}: [state].{key} must be true")
+
+    behavior = contract.get("behavior")
+    if not isinstance(behavior, dict):
+        fail(f"{path}: missing [behavior] table")
+    expected_behavior = {
+        "install": True,
+        "update": False,
+        "prune": False,
+    }
+    for key, expected in expected_behavior.items():
+        if behavior.get(key) is not expected:
+            fail(f"{path}: [behavior].{key} must be {str(expected).lower()}")
+
+    risks = set(contract["risk"])
+    required = {"network", "mutable-user-state"}
+    missing = sorted(required - risks)
+    if missing:
+        fail(f"{path}: npm-globals missing required risks: {', '.join(missing)}")
+
+
+def main() -> int:
+    if not INIT_DIR.is_dir():
+        fail(f"missing init contract directory: {INIT_DIR.relative_to(ROOT)}")
+
+    seen_ids: set[str] = set()
+    active_contracts = 0
+
+    for path in sorted(INIT_DIR.glob("*.toml")):
+        try:
+            contract = tomllib.loads(path.read_text(encoding="utf-8"))
+        except tomllib.TOMLDecodeError as exc:
+            fail(f"{path}: invalid TOML: {exc}")
+
+        _contract_id, kind, enabled = validate_common(path, contract, seen_ids)
+        if kind == "npm-globals":
+            validate_npm_globals(path, contract)
+        if enabled:
+            active_contracts += 1
+
+    if active_contracts == 0:
+        fail("expected at least one enabled init contract")
+
+    print(f"validated {len(seen_ids)} configctl init contract(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify-configctl-contracts.py
+++ b/scripts/verify-configctl-contracts.py
@@ -13,6 +13,11 @@ from pathlib import Path
 from typing import Any
 
 
+def fail(message: str) -> None:
+    print(f"configctl-contracts: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
 def repo_root() -> Path:
     if len(sys.argv) > 2:
         fail("usage: verify-configctl-contracts.py [repo-root]")
@@ -38,11 +43,6 @@ SUPPORTED_ACTIVE_KINDS = {
     "npm-globals",
     "skill-deployment",
 }
-
-
-def fail(message: str) -> None:
-    print(f"configctl-contracts: {message}", file=sys.stderr)
-    raise SystemExit(1)
 
 
 def require_type(contract: dict[str, Any], path: Path, key: str, expected: type) -> Any:

--- a/scripts/verify-configctl-contracts.py
+++ b/scripts/verify-configctl-contracts.py
@@ -40,7 +40,9 @@ SUPPORTED_RISKS = {
 }
 
 SUPPORTED_ACTIVE_KINDS = {
+    "codex-config",
     "npm-globals",
+    "pip-globals",
     "skill-deployment",
 }
 
@@ -91,23 +93,45 @@ def validate_common(path: Path, contract: dict[str, Any], seen_ids: set[str]) ->
     return contract_id, kind, enabled
 
 
-def validate_npm_globals(path: Path, contract: dict[str, Any]) -> None:
+def validate_package_globals(
+    path: Path,
+    contract: dict[str, Any],
+    *,
+    tool: str,
+    expected_prefix: str,
+    expected_bin: str,
+    required_risks: set[str],
+) -> None:
     manifest = require_type(contract, path, "manifest", str)
     prefix = require_type(contract, path, "prefix", str)
     bin_path = require_type(contract, path, "bin", str)
 
-    expected_prefix = "$HOME/.local/share/npm"
-    expected_bin = "$HOME/.local/share/npm/bin"
     if prefix != expected_prefix:
-        fail(f"{path}: prefix must match Home Manager npm prefix {expected_prefix!r}")
+        fail(f"{path}: prefix must match Home Manager {tool} prefix {expected_prefix!r}")
     if bin_path != expected_bin:
-        fail(f"{path}: bin must match Home Manager npm bin path {expected_bin!r}")
+        fail(f"{path}: bin must match Home Manager {tool} bin path {expected_bin!r}")
 
     source_manifest = managed_home_path(manifest)
     if source_manifest is None:
         fail(f"{path}: manifest must be a managed $HOME-relative path")
     if not source_manifest.is_file():
         fail(f"{path}: referenced manifest does not exist: {source_manifest.relative_to(ROOT)}")
+
+    risks = set(contract["risk"])
+    missing = sorted(required_risks - risks)
+    if missing:
+        fail(f"{path}: {tool} missing required risks: {', '.join(missing)}")
+
+
+def validate_npm_globals(path: Path, contract: dict[str, Any]) -> None:
+    validate_package_globals(
+        path,
+        contract,
+        tool="npm-globals",
+        expected_prefix="$HOME/.local/share/npm",
+        expected_bin="$HOME/.local/share/npm/bin",
+        required_risks={"network", "mutable-user-state"},
+    )
 
     state = contract.get("state")
     if not isinstance(state, dict):
@@ -128,11 +152,30 @@ def validate_npm_globals(path: Path, contract: dict[str, Any]) -> None:
         if behavior.get(key) is not expected:
             fail(f"{path}: [behavior].{key} must be {str(expected).lower()}")
 
+
+def validate_pip_globals(path: Path, contract: dict[str, Any]) -> None:
+    validate_package_globals(
+        path,
+        contract,
+        tool="pip-globals",
+        expected_prefix="$XDG_DATA_HOME/pip",
+        expected_bin="$XDG_DATA_HOME/pip/bin",
+        required_risks={"network", "mutable-user-state"},
+    )
+
+
+def validate_codex_config(path: Path, contract: dict[str, Any]) -> None:
+    root = require_type(contract, path, "root", str)
+    output = require_type(contract, path, "output", str)
+
+    if root != "$XDG_CONFIG_HOME/codex":
+        fail(f"{path}: root must be '$XDG_CONFIG_HOME/codex'")
+    if output != "$HOME/.codex/config.toml":
+        fail(f"{path}: output must be '$HOME/.codex/config.toml'")
+
     risks = set(contract["risk"])
-    required = {"network", "mutable-user-state"}
-    missing = sorted(required - risks)
-    if missing:
-        fail(f"{path}: npm-globals missing required risks: {', '.join(missing)}")
+    if risks != {"mutable-user-state"}:
+        fail(f"{path}: codex-config risk must be exactly mutable-user-state")
 
 
 def validate_skill_deployment(path: Path, contract: dict[str, Any]) -> None:
@@ -168,8 +211,12 @@ def main() -> int:
             fail(f"{path}: invalid TOML: {exc}")
 
         _contract_id, kind, enabled = validate_common(path, contract, seen_ids)
-        if kind == "npm-globals":
+        if kind == "codex-config":
+            validate_codex_config(path, contract)
+        elif kind == "npm-globals":
             validate_npm_globals(path, contract)
+        elif kind == "pip-globals":
+            validate_pip_globals(path, contract)
         elif kind == "skill-deployment":
             validate_skill_deployment(path, contract)
         if enabled:

--- a/scripts/verify-configctl-contracts.py
+++ b/scripts/verify-configctl-contracts.py
@@ -27,6 +27,7 @@ SUPPORTED_RISKS = {
 
 SUPPORTED_ACTIVE_KINDS = {
     "npm-globals",
+    "skill-deployment",
 }
 
 
@@ -125,6 +126,25 @@ def validate_npm_globals(path: Path, contract: dict[str, Any]) -> None:
         fail(f"{path}: npm-globals missing required risks: {', '.join(missing)}")
 
 
+def validate_skill_deployment(path: Path, contract: dict[str, Any]) -> None:
+    source = require_type(contract, path, "source", str)
+    target = require_type(contract, path, "target", str)
+
+    if Path(source).is_absolute() or source.startswith("../"):
+        fail(f"{path}: source must be a repository-relative path")
+    if not (ROOT / source).exists():
+        fail(f"{path}: source does not exist: {source}")
+    if not target.startswith(("$HOME/", "~/")):
+        fail(f"{path}: target must be HOME-relative")
+
+    if contract.get("executor_may_initialize") is not False:
+        fail(f"{path}: skill-deployment contracts are documentation-only until a handler exists")
+
+    risks = set(contract["risk"])
+    if risks != {"mutable-user-state"}:
+        fail(f"{path}: skill-deployment risk must be exactly mutable-user-state")
+
+
 def main() -> int:
     if not INIT_DIR.is_dir():
         fail(f"missing init contract directory: {INIT_DIR.relative_to(ROOT)}")
@@ -141,6 +161,8 @@ def main() -> int:
         _contract_id, kind, enabled = validate_common(path, contract, seen_ids)
         if kind == "npm-globals":
             validate_npm_globals(path, contract)
+        elif kind == "skill-deployment":
+            validate_skill_deployment(path, contract)
         if enabled:
             active_contracts += 1
 


### PR DESCRIPTION
## Summary

- Align `npm-globals` with the Dubnium `configctl init` v1 contract shape.
- Keep npm global package installation explicit via `configctl init apply`, not Home Manager activation.
- Add repo-side validation for dotfiles-owned init contracts and wire it into flake checks.
- Update contract/docs wording around discovery, risk metadata, and npm repair flow.

## Validation

- Added `nix run .#verify-configctl-contracts` for direct repo-side contract validation.
- Added `.#checks.x86_64-linux.configctl-contracts` for CI/flake check coverage.
- Could not run Nix locally in this execution container because Nix is not installed.

## Notes

Closes #38.

This intentionally does not implement executor behavior in dotfiles; Dubnium remains responsible for `configctl` runtime discovery, planning, apply, risk gates, and state files.