### PR TITLE
feat: add opsctl user timers

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -223,17 +223,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1783303739,
-        "narHash": "sha256-IMBeZUQH9RRV3wZytMPYvQmMUV71k7Wrv5a4IBz1V/U=",
+        "lastModified": 1783306414,
+        "narHash": "sha256-krKeqwfyivelIchuU7la+r5Gzeoz40QAGrcZ5LgO/co=",
         "ref": "feat/opsctl-minimal-slice",
-        "rev": "ca8961320f2ce959e2e5f951ba80f3fb632ad5ad",
-        "revCount": 2,
+        "rev": "1ded51c5ccce176c0c6e7a9f7f9e8c09592b42a7",
+        "revCount": 3,
         "type": "git",
         "url": "ssh://git@github.com/ryjen/ops-cadence.git"
       },
       "original": {
         "ref": "feat/opsctl-minimal-slice",
-        "rev": "ca8961320f2ce959e2e5f951ba80f3fb632ad5ad",
+        "rev": "1ded51c5ccce176c0c6e7a9f7f9e8c09592b42a7",
         "type": "git",
         "url": "ssh://git@github.com/ryjen/ops-cadence.git"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -216,6 +216,28 @@
         "type": "github"
       }
     },
+    "ops-cadence": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783303739,
+        "narHash": "sha256-IMBeZUQH9RRV3wZytMPYvQmMUV71k7Wrv5a4IBz1V/U=",
+        "ref": "feat/opsctl-minimal-slice",
+        "rev": "ca8961320f2ce959e2e5f951ba80f3fb632ad5ad",
+        "revCount": 2,
+        "type": "git",
+        "url": "ssh://git@github.com/ryjen/ops-cadence.git"
+      },
+      "original": {
+        "ref": "feat/opsctl-minimal-slice",
+        "rev": "ca8961320f2ce959e2e5f951ba80f3fb632ad5ad",
+        "type": "git",
+        "url": "ssh://git@github.com/ryjen/ops-cadence.git"
+      }
+    },
     "pyproject-build-systems": {
       "inputs": {
         "nixpkgs": [
@@ -311,6 +333,7 @@
         "hermes-agent": "hermes-agent",
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs_2",
+        "ops-cadence": "ops-cadence",
         "sops-nix": "sops-nix"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782547241,
-        "narHash": "sha256-Az8k1bRae3Db29KaxBjP4mHGRMLSgbOYC/kcJe4m5oU=",
+        "lastModified": 1783065973,
+        "narHash": "sha256-cl6+ATJ3wni26HQSIJJ+zK1yTEVdKXoSOhr1NeybbPY=",
         "owner": "jacopone",
         "repo": "antigravity-nix",
-        "rev": "c9185eb03f60c2f1a25f78aa5941408ae1852dd3",
+        "rev": "d7eb4913b4f0bcb12023956bbc969c6bad5f7328",
         "type": "github"
       },
       "original": {
@@ -79,43 +79,21 @@
     "git-hooks": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1781733627,
-        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
+        "lastModified": 1783008725,
+        "narHash": "sha256-jGiy6+sxjNWXSjp25uoJuNfyH9zBK1PEDY0lVoL4ibQ=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
+        "rev": "bca82caa46d5ec0f5d422c61fb1e30bc51313cbe",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "gitignore": {
-      "inputs": {
-        "nixpkgs": [
-          "git-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -125,15 +103,15 @@
         "nixpkgs": "nixpkgs",
         "npm-lockfile-fix": "npm-lockfile-fix",
         "pyproject-build-systems": "pyproject-build-systems",
-        "pyproject-nix": "pyproject-nix_2",
-        "uv2nix": "uv2nix_2"
+        "pyproject-nix": "pyproject-nix",
+        "uv2nix": "uv2nix"
       },
       "locked": {
-        "lastModified": 1782623780,
-        "narHash": "sha256-grPiFONbJV6wf4cMzjR+3d6Cxd32Gg8AyD7D58/RrNk=",
+        "lastModified": 1783313339,
+        "narHash": "sha256-8YY/JT1R883/me+bN2m49c0xVVbTwHgnmaw0f2g76zc=",
         "owner": "NousResearch",
         "repo": "hermes-agent",
-        "rev": "54ea059919d57a7a764e7ffaa8cfbf6b56f7e833",
+        "rev": "f761fb9d6a00347b86ac21acdbc38f6044333392",
         "type": "github"
       },
       "original": {
@@ -149,11 +127,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1781981105,
-        "narHash": "sha256-/1nNBbA7PrSQpTc9Qazkhl4kIPg+TNl0CjxS3UQJKlw=",
+        "lastModified": 1783221248,
+        "narHash": "sha256-ESQnuNHEDChsB4IxoLRhscVahqkDWkTb+qdIz8euYt4=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "7bfff44b465909f69a442701293bc0badcf476dc",
+        "rev": "af2beae5f0fae0a4310cc0e6aef2572f56090353",
         "type": "github"
       },
       "original": {
@@ -181,11 +159,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1782375420,
-        "narHash": "sha256-wiPYmEuHbJvleW489n6+lamL7JSJg3pcKUYwURU9CkI=",
+        "lastModified": 1783148766,
+        "narHash": "sha256-uslt2pqShTIXDdAHRHv2QkYLsVdY8Oqwz0EA48/RSM8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4062d36ebeae843c750011eef6b61ec9a9dbc9a9",
+        "rev": "a50de1b7d8a586adc18d2395c19de7d6058e6030",
         "type": "github"
       },
       "original": {
@@ -223,17 +201,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1783306414,
-        "narHash": "sha256-krKeqwfyivelIchuU7la+r5Gzeoz40QAGrcZ5LgO/co=",
+        "lastModified": 1783316801,
+        "narHash": "sha256-VvHc4JRHDmx6caFGjfA6rka+gKnRlYzWi9ndIehU+/E=",
         "ref": "feat/opsctl-minimal-slice",
-        "rev": "1ded51c5ccce176c0c6e7a9f7f9e8c09592b42a7",
-        "revCount": 3,
+        "rev": "f2dbfa1518eaac411ce0cfe08ddef3ad5e87ccb7",
+        "revCount": 5,
         "type": "git",
         "url": "ssh://git@github.com/ryjen/ops-cadence.git"
       },
       "original": {
         "ref": "feat/opsctl-minimal-slice",
-        "rev": "1ded51c5ccce176c0c6e7a9f7f9e8c09592b42a7",
+        "rev": "f2dbfa1518eaac411ce0cfe08ddef3ad5e87ccb7",
         "type": "git",
         "url": "ssh://git@github.com/ryjen/ops-cadence.git"
       }
@@ -244,8 +222,14 @@
           "hermes-agent",
           "nixpkgs"
         ],
-        "pyproject-nix": "pyproject-nix",
-        "uv2nix": "uv2nix"
+        "pyproject-nix": [
+          "hermes-agent",
+          "pyproject-nix"
+        ],
+        "uv2nix": [
+          "hermes-agent",
+          "uv2nix"
+        ]
       },
       "locked": {
         "lastModified": 1772555609,
@@ -265,28 +249,6 @@
       "inputs": {
         "nixpkgs": [
           "hermes-agent",
-          "pyproject-build-systems",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1769936401,
-        "narHash": "sha256-kwCOegKLZJM9v/e/7cqwg1p/YjjTAukKPqmxKnAZRgA=",
-        "owner": "nix-community",
-        "repo": "pyproject.nix",
-        "rev": "b0d513eeeebed6d45b4f2e874f9afba2021f7812",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "pyproject.nix",
-        "type": "github"
-      }
-    },
-    "pyproject-nix_2": {
-      "inputs": {
-        "nixpkgs": [
-          "hermes-agent",
           "nixpkgs"
         ]
       },
@@ -296,28 +258,6 @@
         "owner": "pyproject-nix",
         "repo": "pyproject.nix",
         "rev": "e537db02e72d553cea470976b9733581bcf5b3ed",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pyproject-nix",
-        "repo": "pyproject.nix",
-        "type": "github"
-      }
-    },
-    "pyproject-nix_3": {
-      "inputs": {
-        "nixpkgs": [
-          "hermes-agent",
-          "uv2nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1771518446,
-        "narHash": "sha256-nFJSfD89vWTu92KyuJWDoTQJuoDuddkJV3TlOl1cOic=",
-        "owner": "pyproject-nix",
-        "repo": "pyproject.nix",
-        "rev": "eb204c6b3335698dec6c7fc1da0ebc3c6df05937",
         "type": "github"
       },
       "original": {
@@ -344,11 +284,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782165805,
-        "narHash": "sha256-478kKQBvK6SYTOdN2h9jhKJv94nbXRbFMfuL1WshErg=",
+        "lastModified": 1783174389,
+        "narHash": "sha256-aCWC8ngycU7OdJrU2+Je3qf+1a2ykuBvpPhZT/9tXMc=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "56b24064fdcaedca53553b1a6d607fd23b613a24",
+        "rev": "f1406619a3884cd5c47992a70b8b35c9c0fcb4c9",
         "type": "github"
       },
       "original": {
@@ -376,36 +316,12 @@
       "inputs": {
         "nixpkgs": [
           "hermes-agent",
-          "pyproject-build-systems",
           "nixpkgs"
         ],
         "pyproject-nix": [
           "hermes-agent",
-          "pyproject-build-systems",
           "pyproject-nix"
         ]
-      },
-      "locked": {
-        "lastModified": 1770770348,
-        "narHash": "sha256-A2GzkmzdYvdgmMEu5yxW+xhossP+txrYb7RuzRaqhlg=",
-        "owner": "pyproject-nix",
-        "repo": "uv2nix",
-        "rev": "5d1b2cb4fe3158043fbafbbe2e46238abbc954b0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pyproject-nix",
-        "repo": "uv2nix",
-        "type": "github"
-      }
-    },
-    "uv2nix_2": {
-      "inputs": {
-        "nixpkgs": [
-          "hermes-agent",
-          "nixpkgs"
-        ],
-        "pyproject-nix": "pyproject-nix_3"
       },
       "locked": {
         "lastModified": 1773039484,

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,10 @@
       url = "github:jacopone/antigravity-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    ops-cadence = {
+      url = "git+ssh://git@github.com/ryjen/ops-cadence.git?ref=feat/opsctl-minimal-slice&rev=ca8961320f2ce959e2e5f951ba80f3fb632ad5ad";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     sops-nix = {
       url = "github:Mic92/sops-nix";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -29,6 +33,7 @@
       home-manager,
       hermes-agent,
       antigravity-nix,
+      ops-cadence,
       sops-nix,
       git-hooks,
       ...
@@ -50,6 +55,7 @@
               username
               hermes-agent
               antigravity-nix
+              ops-cadence
               ;
           };
           modules = [
@@ -67,6 +73,7 @@
               username
               hermes-agent
               antigravity-nix
+              ops-cadence
               ;
           };
           modules = [
@@ -82,6 +89,7 @@
                   username
                   hermes-agent
                   antigravity-nix
+                  ops-cadence
                   ;
               };
               home-manager.users.${username} = {
@@ -214,7 +222,7 @@
           home-manager.useGlobalPkgs = true;
           home-manager.useUserPackages = true;
           home-manager.extraSpecialArgs = {
-            inherit self hermes-agent antigravity-nix;
+            inherit self hermes-agent antigravity-nix ops-cadence;
             username = dubniumUsername;
           };
           home-manager.users.${dubniumUsername} = {

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     ops-cadence = {
-      url = "git+ssh://git@github.com/ryjen/ops-cadence.git?ref=feat/opsctl-minimal-slice&rev=ca8961320f2ce959e2e5f951ba80f3fb632ad5ad";
+      url = "git+ssh://git@github.com/ryjen/ops-cadence.git?ref=feat/opsctl-minimal-slice&rev=1ded51c5ccce176c0c6e7a9f7f9e8c09592b42a7";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     sops-nix = {

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     ops-cadence = {
-      url = "git+ssh://git@github.com/ryjen/ops-cadence.git?ref=feat/opsctl-minimal-slice&rev=1ded51c5ccce176c0c6e7a9f7f9e8c09592b42a7";
+      url = "git+ssh://git@github.com/ryjen/ops-cadence.git?ref=feat/opsctl-minimal-slice&rev=f2dbfa1518eaac411ce0cfe08ddef3ad5e87ccb7";
       inputs.nixpkgs.follows = "nixpkgs";
     };
     sops-nix = {

--- a/home/ryjen/profiles/dubnium.nix
+++ b/home/ryjen/profiles/dubnium.nix
@@ -8,6 +8,7 @@
   dotfiles.profiles.browser.enable = true;
   dotfiles.profiles.android.enable = false;
   dotfiles.profiles.micrantha.enable = false;
+  dotfiles.opsCadence.enable = true;
   dotfiles.hypr.adoptedProfile = "dubnium";
 
   dotfiles.music = {

--- a/modules/home/default.nix
+++ b/modules/home/default.nix
@@ -30,6 +30,7 @@
     ./music.nix
     ./neovim.nix
     ./npm.nix
+    ./ops-cadence.nix
     ./pass.nix
     ./pinentry.nix
     ./pip.nix

--- a/modules/home/ops-cadence.nix
+++ b/modules/home/ops-cadence.nix
@@ -1,0 +1,72 @@
+{
+  config,
+  lib,
+  ops-cadence,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.dotfiles.opsCadence;
+  package = cfg.package;
+  mkOpsService = report: {
+    Unit = {
+      Description = "opsctl ${report} report";
+      Documentation = [ "https://github.com/ryjen/ops-cadence" ];
+    };
+    Service = {
+      Type = "oneshot";
+      ExecStart = "${package}/bin/opsctl run ${report}";
+    };
+  };
+  mkOpsTimer = description: calendar: serviceName: {
+    Unit.Description = description;
+    Timer = {
+      OnCalendar = calendar;
+      Persistent = true;
+      Unit = "${serviceName}.service";
+    };
+    Install.WantedBy = [ "timers.target" ];
+  };
+in
+{
+  options.dotfiles.opsCadence = {
+    enable = lib.mkEnableOption "personal ops cadence runner";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = ops-cadence.packages.${pkgs.stdenv.hostPlatform.system}.default;
+      description = "ops-cadence package to install.";
+    };
+
+    timers.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Whether to create user-level systemd timers for opsctl reports.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ package ];
+
+    xdg.configFile."ops-cadence/config.toml".text = ''
+      [state]
+      backend = "memory"
+
+      [llm]
+      base_url = "http://127.0.0.1:8080/v1"
+      model = "local"
+    '';
+
+    systemd.user.services = lib.mkIf (cfg.timers.enable && config.dotfiles.host.userSystemd.enable) {
+      opsctl-career-intelligence = mkOpsService "career-intelligence";
+      opsctl-engineering-portfolio = mkOpsService "engineering-portfolio";
+      opsctl-weekly-review = mkOpsService "weekly-review";
+    };
+
+    systemd.user.timers = lib.mkIf (cfg.timers.enable && config.dotfiles.host.userSystemd.enable) {
+      opsctl-career-intelligence = mkOpsTimer "Daily Career Intelligence" "*-*-* 08:00:00" "opsctl-career-intelligence";
+      opsctl-engineering-portfolio = mkOpsTimer "Weekly Engineering Portfolio Review" "Mon *-*-* 09:30:00" "opsctl-engineering-portfolio";
+      opsctl-weekly-review = mkOpsTimer "Weekly Project Review" "Fri *-*-* 16:30:00" "opsctl-weekly-review";
+    };
+  };
+}

--- a/modules/home/ops-cadence.nix
+++ b/modules/home/ops-cadence.nix
@@ -55,6 +55,14 @@ in
       [llm]
       base_url = "http://127.0.0.1:8080/v1"
       model = "local"
+
+      [sources.github]
+      career_workflows = "ryjen/career-workflows"
+      career_data = "ryjen/career-data"
+
+      [sources.local_git]
+      dubnium = "${config.home.homeDirectory}/.local/src/dubnium"
+      dotfiles = "${config.home.homeDirectory}/.local/src/dubnium/external/dotfiles"
     '';
 
     systemd.user.services = lib.mkIf (cfg.timers.enable && config.dotfiles.host.userSystemd.enable) {


### PR DESCRIPTION
## Summary
- Add ops-cadence flake input pointing at `feat/opsctl-minimal-slice`
- Add Home Manager module (`dotfiles.opsCadence`) for package, config, and `systemd.user` timers
- Activate opsCadence on the dubnium profile
- Bump ops-cadence lock to latest commit

## Timers
- Daily Career Intelligence: daily 08:00
- Engineering Portfolio Review: Monday 09:30
- Weekly Project Review: Friday 16:30

## Validation
- `nix build .#homeConfigurations.ryjen@dubnium.activationPackage --no-link`

> **Cleanup:** Unrelated AI-routing and taskwarrier changes extracted to PRs #77 and #78 respectively.