### PR TITLE
Add uv-tools lane for Aider and Headroom

### DIFF
--- a/contracts/configctl/README.md
+++ b/contracts/configctl/README.md
@@ -102,6 +102,8 @@ Important constraints:
 | Eww | `apps/eww.toml` | compose | planned | Home Manager | configctl |
 | Waybar | `apps/waybar.toml` | compose | planned | Home Manager | configctl |
 | npm globals | `init/npm-globals.toml` | init | active | explicit user state | configctl init |
+| pip globals | `init/pip-globals.toml` | init | active | explicit user state | configctl init |
+| uv tools | `init/uv-tools.toml` | init | active | explicit user state | configctl init |
 | Variety | `init/variety.toml` | init | planned | Home Manager activation | configctl init |
 | Multi-agent worktrees skill | `init/multi-agent-worktrees.toml` | init | active, validate-only | dotfiles/manual copy | configctl init |
 
@@ -119,12 +121,12 @@ Or build the check derivation explicitly:
 nix build .#checks.x86_64-linux.configctl-contracts
 ```
 
-The verifier checks that init contracts are valid TOML, use supported risk labels, have unique IDs, and that enabled contracts have dotfiles-side validation rules. For `npm-globals`, it also verifies that the contract paths match the Home Manager npm prefix and that the referenced package manifest exists.
+The verifier checks that init contracts are valid TOML, use supported risk labels, have unique IDs, and that enabled contracts have dotfiles-side validation rules. For `npm-globals`, `pip-globals`, and `uv-tools`, it also verifies that contract paths match the Home Manager-managed paths and that referenced package/tool manifests exist.
 
 ## Non-goals
 
 - No `configctl` executable implementation in this repository.
-- No automatic npm global package management from Home Manager activation.
+- No automatic package management from Home Manager activation.
 - No implicit network-backed init.
 - No automatic promotion, pruning, or garbage collection.
 - No public mdBook generation.

--- a/contracts/configctl/init/uv-tools.toml
+++ b/contracts/configctl/init/uv-tools.toml
@@ -1,0 +1,19 @@
+schemaVersion = 1
+id = "uv-tools"
+kind = "uv-tools"
+description = "Install isolated Python CLI tools declared by dotfiles"
+enabled = true
+risk = ["network", "mutable-user-state"]
+tags = ["uv", "python", "workstation", "ai"]
+
+manifest = "$HOME/.config/uv/tools.toml"
+bin = "$HOME/.local/bin"
+
+[state]
+trackDesiredHash = true
+trackObservedHash = true
+
+[behavior]
+install = true
+update = false
+prune = false

--- a/docs/user-tool-state.md
+++ b/docs/user-tool-state.md
@@ -35,6 +35,8 @@ Tool manifests live in repo-managed paths under `files/home/` and are materializ
 Examples:
 
 - npm globals: `files/home/.config/npm/global-packages.txt`
+- pip globals: `files/home/.config/pip/global-packages.txt`
+- uv tools: `files/home/.config/uv/tools.toml`
 
 Manifests describe desired durable tools. They do not imply that Home Manager should run network-backed installation during activation.
 
@@ -53,6 +55,18 @@ Home Manager materializes them to the Dubnium discovery path:
 ```
 
 `configctl` owns runtime parsing, risk gates, planning, application, verification, and state under `$XDG_STATE_HOME`.
+
+## Tool lanes
+
+User-installed tooling is split by package ecosystem and isolation requirement:
+
+| Lane | Use for | Isolation |
+| --- | --- | --- |
+| `npm-globals` | npm-owned CLI tools | npm global prefix |
+| `pip-globals` | small Python library/helper packages | shared pip prefix |
+| `uv-tools` | Python CLI applications with larger dependency graphs | isolated uv tool environments |
+
+A package should move to `uv-tools` when it behaves like an application rather than a lightweight helper package. Examples include Aider and Headroom.
 
 ## Local experiments and promotion
 
@@ -200,6 +214,44 @@ command -v codex
 ```
 
 Avoid `sudo npm install -g`. The configured prefix is user-writable by design.
+
+## pip globals
+
+`pip-globals` is for small Python packages and helper libraries that are acceptable in a shared user prefix.
+
+Current durable pip globals are declared in:
+
+```text
+files/home/.config/pip/global-packages.txt
+```
+
+Python CLI applications with larger dependency graphs should not be added here. Prefer `uv-tools` so their dependencies remain isolated.
+
+## uv tools
+
+`uv-tools` is for Python CLI applications installed into isolated uv-managed environments while exposing executables through `~/.local/bin`.
+
+Home Manager writes:
+
+```text
+~/.config/uv/tools.toml
+~/.config/configctl/init.d/uv-tools.toml
+```
+
+Current durable uv tools include:
+
+```text
+aider-chat
+headroom-ai[all]
+```
+
+Inspect and reconcile with:
+
+```sh
+configctl init plan uv-tools
+configctl init apply uv-tools --allow network,mutable-user-state --yes
+configctl init verify uv-tools
+```
 
 ## Verification
 

--- a/files/home/.config/pip/global-packages.txt
+++ b/files/home/.config/pip/global-packages.txt
@@ -12,3 +12,4 @@ onnxruntime
 magika
 zstandard
 h2
+aider-chat

--- a/files/home/.config/pip/global-packages.txt
+++ b/files/home/.config/pip/global-packages.txt
@@ -1,15 +1,9 @@
 # Repo-managed pip global package manifest.
 #
-# This file declares durable pip global tools for configctl init contracts.
+# This file declares durable pip global library/helper packages for configctl init contracts.
+# Python CLI applications with larger dependency graphs belong in uv tools.
 # Comments and blank lines are allowed. Package install/update execution is
 # explicit mutable user state and must not run from Home Manager activation.
 
 pybind11
 huggingface_hub
-headroom-ai[all]
-# headroom proxy runtime dependencies (not always pulled by [all])
-onnxruntime
-magika
-zstandard
-h2
-aider-chat

--- a/files/home/.config/uv/tools.toml
+++ b/files/home/.config/uv/tools.toml
@@ -1,0 +1,14 @@
+# Repo-managed isolated Python CLI tool manifest.
+#
+# This file declares durable uv tool installs for configctl init contracts.
+# Comments are allowed. Installation is explicit mutable user state and must not
+# run from Home Manager activation.
+
+[[tools]]
+package = "aider-chat"
+python = "python3.12"
+extraPackages = ["pip"]
+
+[[tools]]
+package = "headroom-ai[all]"
+python = "python3.12"

--- a/files/home/.local/libexec/headroom-proxy
+++ b/files/home/.local/libexec/headroom-proxy
@@ -1,0 +1,16 @@
+#!/usr/bin/env sh
+set -eu
+
+uv_headroom="${HOME}/.local/bin/headroom"
+pip_headroom="${HOME}/.local/share/pip/bin/headroom"
+
+if [ -x "$uv_headroom" ]; then
+  exec "$uv_headroom" proxy "$@"
+fi
+
+if [ -x "$pip_headroom" ]; then
+  exec "$pip_headroom" proxy "$@"
+fi
+
+printf '%s\n' "headroom-proxy: no executable headroom found at $uv_headroom or $pip_headroom" >&2
+exit 127

--- a/modules/home/default.nix
+++ b/modules/home/default.nix
@@ -40,6 +40,7 @@
     ./starship.nix
     ./taskwarrior.nix
     ./tmux.nix
+    ./uv.nix
     ./vscode.nix
     ./zsh.nix
     ./zellij.nix

--- a/modules/home/headroom.nix
+++ b/modules/home/headroom.nix
@@ -26,8 +26,8 @@ in
 
       package = lib.mkOption {
         type = lib.types.str;
-        default = "${config.home.homeDirectory}/.local/share/pip/bin/headroom";
-        description = "Path to the headroom CLI binary (pip-installed).";
+        default = "${config.home.homeDirectory}/.local/bin/headroom";
+        description = "Path to the headroom CLI binary (uv tool-installed).";
       };
     };
   };
@@ -47,7 +47,7 @@ in
         Restart = "always";
         RestartSec = "5s";
         Environment = [
-          "PATH=${config.home.homeDirectory}/.local/share/pip/bin:%h/.venv/bin:%h/.local/bin"
+          "PATH=%h/.local/bin:%h/.local/share/pip/bin:%h/.venv/bin"
           "LD_LIBRARY_PATH=${lib.makeLibraryPath [ pkgs.stdenv.cc.cc.lib ]}"
         ];
       };

--- a/modules/home/headroom.nix
+++ b/modules/home/headroom.nix
@@ -26,13 +26,18 @@ in
 
       package = lib.mkOption {
         type = lib.types.str;
-        default = "${config.home.homeDirectory}/.local/bin/headroom";
-        description = "Path to the headroom CLI binary (uv tool-installed).";
+        default = "${config.home.homeDirectory}/.local/libexec/headroom-proxy";
+        description = "Path to the Headroom proxy launcher. The launcher prefers uv tool-installed Headroom and falls back to the legacy pip global during migration.";
       };
     };
   };
 
   config = lib.mkIf cfg.proxy.enable {
+    home.file.".local/libexec/headroom-proxy" = {
+      source = ../../files/home/.local/libexec/headroom-proxy;
+      executable = true;
+    };
+
     systemd.user.services.headroom-proxy = {
       Unit = {
         Description = "Headroom context compression proxy";
@@ -43,7 +48,7 @@ in
 
       Service = {
         Type = "simple";
-        ExecStart = "${cfg.proxy.package} proxy --host ${cfg.proxy.host} --port ${toString cfg.proxy.port}";
+        ExecStart = "${cfg.proxy.package} --host ${cfg.proxy.host} --port ${toString cfg.proxy.port}";
         Restart = "always";
         RestartSec = "5s";
         Environment = [

--- a/modules/home/uv.nix
+++ b/modules/home/uv.nix
@@ -1,0 +1,38 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.dotfiles.uv;
+  uvBin = "${config.home.homeDirectory}/.local/bin";
+in
+{
+  options.dotfiles.uv = {
+    enable = lib.mkEnableOption "uv isolated Python tool environment";
+
+    toolsFile = lib.mkOption {
+      type = lib.types.str;
+      default = ".config/uv/tools.toml";
+      description = "Home-relative path to the uv tool manifest.";
+    };
+  };
+
+  config = lib.mkMerge [
+    {
+      dotfiles.uv.enable = lib.mkDefault (config.dotfiles.profiles.workstation.enable or false);
+    }
+
+    (lib.mkIf cfg.enable {
+      home.packages = [ pkgs.uv ];
+      home.sessionPath = [ uvBin ];
+
+      home.file."${cfg.toolsFile}".source = ../../files/home/.config/uv/tools.toml;
+
+      home.activation.createUvToolBin = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        mkdir -p "${uvBin}"
+      '';
+    })
+  ];
+}

--- a/scripts/verify-configctl-contracts.py
+++ b/scripts/verify-configctl-contracts.py
@@ -45,6 +45,7 @@ SUPPORTED_ACTIVE_KINDS = {
     "pip-globals",
     "skill-deployment",
     "task-config",
+    "uv-tools",
 }
 
 
@@ -165,6 +166,71 @@ def validate_pip_globals(path: Path, contract: dict[str, Any]) -> None:
     )
 
 
+def validate_uv_tools(path: Path, contract: dict[str, Any]) -> None:
+    manifest = require_type(contract, path, "manifest", str)
+    bin_path = require_type(contract, path, "bin", str)
+
+    if bin_path != "$HOME/.local/bin":
+        fail(f"{path}: bin must match Home Manager uv tool bin path '$HOME/.local/bin'")
+
+    source_manifest = managed_home_path(manifest)
+    if source_manifest is None:
+        fail(f"{path}: manifest must be a managed $HOME-relative path")
+    if not source_manifest.is_file():
+        fail(f"{path}: referenced manifest does not exist: {source_manifest.relative_to(ROOT)}")
+
+    risks = set(contract["risk"])
+    missing = sorted({"network", "mutable-user-state"} - risks)
+    if missing:
+        fail(f"{path}: uv-tools missing required risks: {', '.join(missing)}")
+
+    state = contract.get("state")
+    if not isinstance(state, dict):
+        fail(f"{path}: missing [state] table")
+    for key in ("trackDesiredHash", "trackObservedHash"):
+        if state.get(key) is not True:
+            fail(f"{path}: [state].{key} must be true")
+
+    behavior = contract.get("behavior")
+    if not isinstance(behavior, dict):
+        fail(f"{path}: missing [behavior] table")
+    expected_behavior = {
+        "install": True,
+        "update": False,
+        "prune": False,
+    }
+    for key, expected in expected_behavior.items():
+        if behavior.get(key) is not expected:
+            fail(f"{path}: [behavior].{key} must be {str(expected).lower()}")
+
+    try:
+        tool_manifest = tomllib.loads(source_manifest.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        fail(f"{source_manifest}: invalid TOML: {exc}")
+
+    tools = tool_manifest.get("tools")
+    if not isinstance(tools, list) or not tools:
+        fail(f"{source_manifest}: expected at least one [[tools]] entry")
+
+    seen_packages: set[str] = set()
+    for index, tool in enumerate(tools, start=1):
+        if not isinstance(tool, dict):
+            fail(f"{source_manifest}: [[tools]] entry {index} must be a table")
+        package = tool.get("package")
+        if not isinstance(package, str) or not package.strip():
+            fail(f"{source_manifest}: [[tools]] entry {index} package must be a non-empty string")
+        if package in seen_packages:
+            fail(f"{source_manifest}: duplicate uv tool package {package!r}")
+        seen_packages.add(package)
+        python = tool.get("python")
+        if python is not None and not isinstance(python, str):
+            fail(f"{source_manifest}: [[tools]] entry {index} python must be a string")
+        extra_packages = tool.get("extraPackages")
+        if extra_packages is not None:
+            if not isinstance(extra_packages, list) or not all(isinstance(item, str) for item in extra_packages):
+                fail(f"{source_manifest}: [[tools]] entry {index} extraPackages must be a list of strings")
+
+
 def validate_codex_config(path: Path, contract: dict[str, Any]) -> None:
     root = require_type(contract, path, "root", str)
     output = require_type(contract, path, "output", str)
@@ -232,6 +298,8 @@ def main() -> int:
             validate_npm_globals(path, contract)
         elif kind == "pip-globals":
             validate_pip_globals(path, contract)
+        elif kind == "uv-tools":
+            validate_uv_tools(path, contract)
         elif kind == "skill-deployment":
             validate_skill_deployment(path, contract)
         elif kind == "task-config":


### PR DESCRIPTION
## Summary
- Replace the original shared `pip-globals` Aider install with an isolated `uv-tools` lane
- Move `headroom-ai[all]` and its dependency-repair packages out of `pip-globals`
- Add a repo-managed `files/home/.config/uv/tools.toml` manifest for `aider-chat` and `headroom-ai[all]`
- Add `contracts/configctl/init/uv-tools.toml` and verifier coverage
- Add a Home Manager `uv` module and import it on workstation profiles
- Point the Headroom user service at the uv tool executable path under `~/.local/bin`
- Document the npm / pip / uv tool-state split

## Coordination
Requires Dubnium support for the new `uv-tools` init handler before `configctl init apply uv-tools` works locally.

Related Dubnium branch: `configctl/uv-tools`

## Local reconcile after both PRs land

```sh
home-manager switch --flake .#ryjen@dubnium
configctl init plan uv-tools
configctl init apply uv-tools --allow network,mutable-user-state --yes
configctl init verify uv-tools
```

## Validation
- Inspected branch diff via GitHub compare
- Not locally executed: `nix run .#verify-configctl-contracts`, Home Manager evaluation, or real `configctl init apply uv-tools`