### PR TITLE
Tune Waybar widget spacing and visibility

### DIFF
--- a/.changelog/waybar-widget-spacing-and-visible-fans.md
+++ b/.changelog/waybar-widget-spacing-and-visible-fans.md
@@ -1,6 +1,0 @@
-# Waybar widget spacing and visibility
-
-- Add spacing after the compact NVIDIA GPU icon.
-- Add spacing between PulseAudio output and source/input text.
-- Keep the fan widget visible with a placeholder when no RPM sensors are exposed.
-- Remove the non-functional custom backlight widget from the default/dubnium Waybar config while leaving technetium unchanged.

--- a/.changelog/waybar-widget-spacing-and-visible-fans.md
+++ b/.changelog/waybar-widget-spacing-and-visible-fans.md
@@ -1,0 +1,6 @@
+# Waybar widget spacing and visibility
+
+- Add spacing after the compact NVIDIA GPU icon.
+- Add spacing between PulseAudio output and source/input text.
+- Keep the fan widget visible with a placeholder when no RPM sensors are exposed.
+- Remove the non-functional custom backlight widget from the default/dubnium Waybar config while leaving technetium unchanged.

--- a/files/home/.config/waybar/config-technetium.jsonc
+++ b/files/home/.config/waybar/config-technetium.jsonc
@@ -141,9 +141,9 @@
         "bat": "BAT0"
     },
     "pulseaudio": {
-        "format": "{volume}% {icon} {format_source}",
-        "format-bluetooth": "{volume}% {icon} {format_source}",
-        "format-muted": " {format_source}",
+        "format": "{volume}% {icon}  {format_source}",
+        "format-bluetooth": "{volume}% {icon}  {format_source}",
+        "format-muted": "  {format_source}",
         "format-source": "{volume}% ",
         "format-source-muted": "",
         "format-icons": {

--- a/files/home/.config/waybar/config.jsonc
+++ b/files/home/.config/waybar/config.jsonc
@@ -26,7 +26,6 @@
         "temperature",
         "custom/fans",
         "custom/nvidia-gpu",
-        "custom/backlight",
         "clock",
         "hyprland/language",
         "custom/power"
@@ -81,14 +80,6 @@
         "on-scroll-down": "brightnessctl set 1%-",
         "min-length": 6
     },
-    "custom/backlight": {
-        "exec": "brightnessctl -m | cut -d, -f4",
-        "interval": 1,
-        "format": "󰃠 {}",
-        "on-scroll-up": "brightnessctl set 1%+",
-        "on-scroll-down": "brightnessctl set 1%-",
-        "tooltip": false
-    },
     "temperature": {
         "critical-threshold": 80,
         "format": "{icon} {temperatureC}°C",
@@ -123,9 +114,9 @@
         "max-length": 30
     },
     "pulseaudio": {
-        "format": "{volume}% {icon} {format_source}",
-        "format-bluetooth": "{volume}% {icon} {format_source}",
-        "format-muted": " {format_source}",
+        "format": "{volume}% {icon}  {format_source}",
+        "format-bluetooth": "{volume}% {icon}  {format_source}",
+        "format-muted": "  {format_source}",
         "format-source": "{volume}% ",
         "format-source-muted": "",
         "format-icons": {

--- a/files/home/.config/waybar/scripts/fans
+++ b/files/home/.config/waybar/scripts/fans
@@ -2,15 +2,15 @@
 set -euo pipefail
 
 # Emit a Waybar JSON payload for hardware fan speeds exposed by lm_sensors.
-# Keep this script host-safe: machines without readable fan sensors should render
-# nothing instead of causing repeated Waybar errors.
+# Keep this widget visible even when the host does not expose fan RPM sensors so
+# operators can distinguish "not wired" from a missing Waybar module.
 if ! command -v sensors >/dev/null 2>&1; then
-  printf '{"text":"","tooltip":"sensors not found","class":"missing"}\n'
+  printf '{"text":"󰈐 --","tooltip":"sensors not found","class":"missing"}\n'
   exit 0
 fi
 
 if ! output="$(sensors 2>/dev/null)"; then
-  printf '{"text":"","tooltip":"sensors failed","class":"error"}\n'
+  printf '{"text":"󰈐 err","tooltip":"sensors failed","class":"error"}\n'
   exit 0
 fi
 
@@ -32,7 +32,7 @@ fans="$(
 )"
 
 if [ -z "$fans" ]; then
-  printf '{"text":"","tooltip":"No fan RPM sensors reported","class":"missing"}\n'
+  printf '{"text":"󰈐 --","tooltip":"No fan RPM sensors reported","class":"missing"}\n'
   exit 0
 fi
 

--- a/files/home/.config/waybar/scripts/nvidia-gpu
+++ b/files/home/.config/waybar/scripts/nvidia-gpu
@@ -60,6 +60,6 @@ name="$(trim "$name")"
 name_escaped="$(json_escape "$name")"
 vram_pct="$(percent "$mem_used" "$mem_total")"
 
-printf '{"text":"󰢮 %s%%/%s%%","tooltip":"%s\\nGPU: %s%%\\nVRAM: %s%% (%s / %s MiB)\\nTemp: %s°C\\nPower: %s / %s W\\nFan: %s%%","class":"nvidia"}\n' \
+printf '{"text":"󰢮  %s%%/%s%%","tooltip":"%s\\nGPU: %s%%\\nVRAM: %s%% (%s / %s MiB)\\nTemp: %s°C\\nPower: %s / %s W\\nFan: %s%%","class":"nvidia"}\n' \
   "$util" "$vram_pct" \
   "$name_escaped" "$util" "$vram_pct" "$mem_used" "$mem_total" "$temp" "$power" "$power_limit" "$fan"


### PR DESCRIPTION
## Summary
- add spacing after the compact NVIDIA GPU icon
- add spacing between PulseAudio output and input/source text
- keep the fan widget visible with a placeholder when fan RPM sensors are unavailable
- remove the non-functional custom backlight widget from the default/dubnium Waybar config
- leave the technetium backlight widget intact

## Notes
- The fan widget now shows `󰈐 --` when `sensors` is missing or no fan RPM sensors are exposed, so the module is visibly present for debugging.
- The default Waybar config no longer includes `custom/backlight`; `config-technetium.jsonc` still does.