### PR TITLE
Fix Neovim Treesitter installation

### DIFF
--- a/files/home/.config/nvim/plugin/treesitter.lua
+++ b/files/home/.config/nvim/plugin/treesitter.lua
@@ -5,7 +5,7 @@ if not ok then
 end
 
 ts_configs.setup({
-	ensure_installed = "all",
+	auto_install = false,
 	highlight = { enable = true, use_languagetree = true },
 	indent = { enable = false },
 	incremental_selection = {

--- a/modules/home/neovim.nix
+++ b/modules/home/neovim.nix
@@ -11,6 +11,10 @@
     withRuby = true;
     withPython3 = true;
 
+    plugins = with pkgs.vimPlugins; [
+      nvim-treesitter.withAllGrammars
+    ];
+
     # External tools used by the Lua config and plugin integrations.
     # Keep this list explicit so Neovim behavior stays reproducible under Nix.
     extraPackages = with pkgs; [


### PR DESCRIPTION
## Summary
- install `nvim-treesitter.withAllGrammars` through the Home Manager Neovim module
- keep Treesitter parser availability declarative under Nix instead of relying on mutable runtime installs
- disable Treesitter `auto_install` in Lua now that grammars are provided by Nix

## Notes
- This addresses `nvim-treesitter is unavailable; skipping Treesitter setup` by putting the plugin on Neovim's runtimepath.
- `ensure_installed = "all"` was removed because it conflicts with the repo's reproducible Nix-owned plugin model.

## Validation
- Not run here; recommended local check:
  - `home-manager switch`
  - `nvim --headless '+checkhealth nvim-treesitter' +qa`
  - `nvim --headless +'lua print(vim.inspect(vim.api.nvim_get_runtime_file("lua/nvim-treesitter/configs.lua", false)))' +qa`