### PR TITLE
Add minimal mpv music integration

### DIFF
--- a/files/home/.config/waybar/config-technetium.jsonc
+++ b/files/home/.config/waybar/config-technetium.jsonc
@@ -17,7 +17,7 @@
         "hyprland/window"
     ],
     "modules-right": [
-        "mpris",
+        "custom/music",
         "idle_inhibitor",
         "pulseaudio",
         "power-profiles-daemon",
@@ -109,23 +109,17 @@
         "format": "{}",
         "tooltip": true
     },
-    "mpris": {
-        "format": "{player_icon} {dynamic}",
-        "format-paused": "{status_icon} <i>{dynamic}</i>",
-        "player-icons": {
-            "default": "▶",
-            "mpv": "",
-            "spotify": "",
-            "firefox": "",
-            "chrome": ""
-        },
-        "status-icons": {
-            "paused": "⏸"
-        },
-        "max-length": 30,
-        "on-click": "playerctl play-pause",
-        "on-click-right": "playerctl next",
-        "on-click-middle": "playerctl previous"
+    "custom/music": {
+        "exec": "playerctl --player=mpv metadata --format '{{artist}} - {{title}}' 2>/dev/null || true",
+        "interval": 2,
+        "format": " {}",
+        "max-length": 36,
+        "escape": true,
+        "on-click": "playerctl --player=mpv play-pause",
+        "on-click-right": "playerctl --player=mpv next",
+        "on-click-middle": "playerctl --player=mpv previous",
+        "on-click-backward": "music-eq",
+        "on-click-forward": "music-eq service"
     },
     "battery": {
         "states": {

--- a/files/home/.config/waybar/config-technetium.jsonc
+++ b/files/home/.config/waybar/config-technetium.jsonc
@@ -114,6 +114,7 @@
         "format-paused": "{status_icon} <i>{dynamic}</i>",
         "player-icons": {
             "default": "▶",
+            "mpv": "",
             "spotify": "",
             "firefox": "",
             "chrome": ""
@@ -121,7 +122,10 @@
         "status-icons": {
             "paused": "⏸"
         },
-        "max-length": 30
+        "max-length": 30,
+        "on-click": "playerctl play-pause",
+        "on-click-right": "playerctl next",
+        "on-click-middle": "playerctl previous"
     },
     "battery": {
         "states": {

--- a/files/home/.config/waybar/config.jsonc
+++ b/files/home/.config/waybar/config.jsonc
@@ -104,6 +104,7 @@
         "format-paused": "{status_icon} <i>{dynamic}</i>",
         "player-icons": {
             "default": "▶",
+            "mpv": "",
             "spotify": "",
             "firefox": "",
             "chrome": ""
@@ -111,7 +112,10 @@
         "status-icons": {
             "paused": "⏸"
         },
-        "max-length": 30
+        "max-length": 30,
+        "on-click": "playerctl play-pause",
+        "on-click-right": "playerctl next",
+        "on-click-middle": "playerctl previous"
     },
     "pulseaudio": {
         "format": "{volume}% {icon}  {format_source}",

--- a/files/home/.config/waybar/config.jsonc
+++ b/files/home/.config/waybar/config.jsonc
@@ -17,7 +17,7 @@
         "hyprland/window"
     ],
     "modules-right": [
-        "mpris",
+        "custom/music",
         "idle_inhibitor",
         "pulseaudio",
         "power-profiles-daemon",
@@ -99,23 +99,17 @@
         "format": "{}",
         "tooltip": true
     },
-    "mpris": {
-        "format": "{player_icon} {dynamic}",
-        "format-paused": "{status_icon} <i>{dynamic}</i>",
-        "player-icons": {
-            "default": "▶",
-            "mpv": "",
-            "spotify": "",
-            "firefox": "",
-            "chrome": ""
-        },
-        "status-icons": {
-            "paused": "⏸"
-        },
-        "max-length": 30,
-        "on-click": "playerctl play-pause",
-        "on-click-right": "playerctl next",
-        "on-click-middle": "playerctl previous"
+    "custom/music": {
+        "exec": "playerctl --player=mpv metadata --format '{{artist}} - {{title}}' 2>/dev/null || true",
+        "interval": 2,
+        "format": " {}",
+        "max-length": 36,
+        "escape": true,
+        "on-click": "playerctl --player=mpv play-pause",
+        "on-click-right": "playerctl --player=mpv next",
+        "on-click-middle": "playerctl --player=mpv previous",
+        "on-click-backward": "music-eq",
+        "on-click-forward": "music-eq service"
     },
     "pulseaudio": {
         "format": "{volume}% {icon}  {format_source}",

--- a/files/home/.config/waybar/style.css
+++ b/files/home/.config/waybar/style.css
@@ -45,7 +45,7 @@ window#waybar {
     color: #7aa2f7;
 }
 
-#battery, #clock, #cpu, #memory, #temperature, #backlight, #custom-backlight, #network, #pulseaudio, #custom-media, #tray, #mode, #idle_inhibitor, #custom-power, #language {
+#battery, #clock, #cpu, #memory, #temperature, #backlight, #custom-backlight, #network, #pulseaudio, #mpris, #custom-media, #tray, #mode, #idle_inhibitor, #custom-power, #language {
     padding: 0 14px;
     margin: 4px 2px;
     border-radius: 8px;

--- a/files/home/.config/waybar/style.css
+++ b/files/home/.config/waybar/style.css
@@ -45,7 +45,7 @@ window#waybar {
     color: #7aa2f7;
 }
 
-#battery, #clock, #cpu, #memory, #temperature, #backlight, #custom-backlight, #network, #pulseaudio, #mpris, #custom-media, #tray, #mode, #idle_inhibitor, #custom-power, #language {
+#battery, #clock, #cpu, #memory, #temperature, #backlight, #custom-backlight, #network, #pulseaudio, #custom-music, #custom-media, #tray, #mode, #idle_inhibitor, #custom-power, #language {
     padding: 0 14px;
     margin: 4px 2px;
     border-radius: 8px;

--- a/files/home/.local/bin/music
+++ b/files/home/.local/bin/music
@@ -3,11 +3,15 @@ set -euo pipefail
 
 music_dir="${MPV_MUSIC_DIR:-${DUBNIUM_MUSIC_DIR:-$HOME/Music}}"
 
+mpv_music_args=(
+  --no-video
+  --audio-display=no
+  --loop-playlist=inf
+  --save-position-on-quit
+)
+
 if [ "$#" -gt 0 ]; then
-  exec mpv \
-    --loop-playlist=inf \
-    --save-position-on-quit \
-    "$@"
+  exec mpv "${mpv_music_args[@]}" "$@"
 fi
 
 if [ ! -d "$music_dir" ]; then
@@ -16,7 +20,6 @@ if [ ! -d "$music_dir" ]; then
 fi
 
 exec mpv \
+  "${mpv_music_args[@]}" \
   --shuffle \
-  --loop-playlist=inf \
-  --save-position-on-quit \
   "$music_dir"

--- a/files/home/.local/bin/music-dislike
+++ b/files/home/.local/bin/music-dislike
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+uri="$(playerctl --player=mpv metadata xesam:url 2>/dev/null || true)"
+
+if [ -z "$uri" ]; then
+  printf 'music-dislike: no mpv track URL found\n' >&2
+  exit 1
+fi
+
+case "$uri" in
+  file://*)
+    ;;
+  *)
+    printf 'music-dislike: refusing non-local track URL: %s\n' "$uri" >&2
+    exit 1
+    ;;
+esac
+
+path="$(python3 - "$uri" <<'PY'
+import sys
+from urllib.parse import unquote, urlparse
+
+parsed = urlparse(sys.argv[1])
+if parsed.scheme != "file":
+    raise SystemExit(1)
+print(unquote(parsed.path))
+PY
+)"
+
+if [ ! -f "$path" ]; then
+  printf 'music-dislike: current track is not a file: %s\n' "$path" >&2
+  exit 1
+fi
+
+playerctl --player=mpv next 2>/dev/null || true
+sleep 0.25
+trash-put -- "$path"
+printf 'music-dislike: moved to trash: %s\n' "$path"

--- a/files/home/.local/bin/music-eq
+++ b/files/home/.local/bin/music-eq
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+usage: music-eq [open|service|preset NAME]
+
+Manage EasyEffects for local music playback.
+
+Commands:
+  open          Open the EasyEffects UI (default)
+  service       Start EasyEffects hidden as a background application service
+  preset NAME   Load an EasyEffects preset by name
+
+Examples:
+  music-eq
+  music-eq service
+  music-eq preset Headphones
+USAGE
+}
+
+cmd="${1:-open}"
+
+case "$cmd" in
+  open)
+    exec easyeffects
+    ;;
+  service)
+    exec easyeffects --gapplication-service
+    ;;
+  preset)
+    if [ "$#" -ne 2 ]; then
+      usage >&2
+      exit 2
+    fi
+    exec easyeffects --load-preset "$2"
+    ;;
+  -h|--help|help)
+    usage
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/files/home/.local/bin/music-window
+++ b/files/home/.local/bin/music-window
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+music_dir="${MPV_MUSIC_DIR:-${DUBNIUM_MUSIC_DIR:-$HOME/Music}}"
+
+mpv_music_window_args=(
+  --force-window=yes
+  --audio-display=embedded-first
+  --loop-playlist=inf
+  --save-position-on-quit
+)
+
+if [ "$#" -gt 0 ]; then
+  exec mpv "${mpv_music_window_args[@]}" "$@"
+fi
+
+if [ ! -d "$music_dir" ]; then
+  printf 'music directory not found: %s\n' "$music_dir" >&2
+  exit 1
+fi
+
+exec mpv \
+  "${mpv_music_window_args[@]}" \
+  --shuffle \
+  "$music_dir"

--- a/modules/home/music.nix
+++ b/modules/home/music.nix
@@ -44,6 +44,11 @@ in
       executable = true;
     };
 
+    home.file.".local/bin/music-window" = {
+      source = ../../files/home/.local/bin/music-window;
+      executable = true;
+    };
+
     home.file.".local/bin/music-eq" = {
       source = ../../files/home/.local/bin/music-eq;
       executable = true;

--- a/modules/home/music.nix
+++ b/modules/home/music.nix
@@ -22,6 +22,8 @@ in
     home.packages = with pkgs; [
       easyeffects
       playerctl
+      python3
+      trash-cli
     ];
 
     programs.mpv = {
@@ -35,13 +37,17 @@ in
         audio-display = "no";
         save-position-on-quit = "yes";
       };
+
+      bindings = {
+        "Shift+DELETE" = "run ${config.home.homeDirectory}/.local/bin/music-dislike";
+      };
     };
 
     xdg.desktopEntries.music-window = {
       name = "Music Window";
       genericName = "Music Player";
       comment = "Open the local music library in mpv's graphical window";
-      exec = "music-window";
+      exec = "${config.home.homeDirectory}/.local/bin/music-window";
       terminal = false;
       categories = [ "Audio" "Music" "Player" ];
     };
@@ -60,6 +66,11 @@ in
 
     home.file.".local/bin/music-eq" = {
       source = ../../files/home/.local/bin/music-eq;
+      executable = true;
+    };
+
+    home.file.".local/bin/music-dislike" = {
+      source = ../../files/home/.local/bin/music-dislike;
       executable = true;
     };
   };

--- a/modules/home/music.nix
+++ b/modules/home/music.nix
@@ -20,9 +20,21 @@ in
 
   config = lib.mkIf cfg.enable {
     home.packages = with pkgs; [
-      mpv
       playerctl
     ];
+
+    programs.mpv = {
+      enable = true;
+
+      scripts = with pkgs.mpvScripts; [
+        mpris
+      ];
+
+      config = {
+        audio-display = "no";
+        save-position-on-quit = "yes";
+      };
+    };
 
     home.sessionVariables.DUBNIUM_MUSIC_DIR = cfg.musicDirectory;
 

--- a/modules/home/music.nix
+++ b/modules/home/music.nix
@@ -20,6 +20,7 @@ in
 
   config = lib.mkIf cfg.enable {
     home.packages = with pkgs; [
+      easyeffects
       playerctl
     ];
 
@@ -40,6 +41,11 @@ in
 
     home.file.".local/bin/music" = {
       source = ../../files/home/.local/bin/music;
+      executable = true;
+    };
+
+    home.file.".local/bin/music-eq" = {
+      source = ../../files/home/.local/bin/music-eq;
       executable = true;
     };
   };

--- a/modules/home/music.nix
+++ b/modules/home/music.nix
@@ -37,6 +37,15 @@ in
       };
     };
 
+    xdg.desktopEntries.music-window = {
+      name = "Music Window";
+      genericName = "Music Player";
+      comment = "Open the local music library in mpv's graphical window";
+      exec = "music-window";
+      terminal = false;
+      categories = [ "Audio" "Music" "Player" ];
+    };
+
     home.sessionVariables.DUBNIUM_MUSIC_DIR = cfg.musicDirectory;
 
     home.file.".local/bin/music" = {


### PR DESCRIPTION
## Summary

- configure Home Manager mpv with the MPRIS script for Waybar/playerctl integration
- keep `music` as an audio-only mpv launcher with shared defaults
- add `music-window` for mpv's graphical window/OSC mode and expose it as a desktop launcher for `SUPER+R` / drun
- install EasyEffects with the music tooling and add a `music-eq` helper for opening the UI, running the background service, or loading a preset
- add `music-dislike` to skip the current mpv track and move the local file to Trash
- split Waybar media handling:
  - `custom/media` remains generic playerctl/MPRIS for browsers, Spotify, etc.
  - `custom/music` is mpv-only and includes EasyEffects mouse-button actions
- style the dedicated `custom/music` widget like the other status blocks

## Usage

```sh
music
music /path/to/album-or-track
music-window
music-window /path/to/album-or-track
music-eq
music-eq service
music-eq preset Headphones
music-dislike
```

## mpv controls

- `Shift+Delete`: skip the current mpv track and move the local file to Trash

## Waybar controls

- left click: mpv play/pause
- right click: mpv next
- middle click: mpv previous
- mouse back: open EasyEffects
- mouse forward: start EasyEffects hidden

## Notes

- This intentionally does not add mpv crossfade yet; crossfade remains a separate, less-stable concern.
- EasyEffects is used for EQ at the PipeWire/session layer rather than encoding EQ filters into mpv flags.
- Disliked tracks are moved with `trash-put`; they are not permanently deleted.

## Validation

- Compared branch against `main`; changes are limited to music tooling and Waybar media integration.