### PR TITLE
Fix Waybar music widget text color

### DIFF
--- a/files/home/.config/waybar/style.css
+++ b/files/home/.config/waybar/style.css
@@ -62,6 +62,10 @@ window#waybar {
     color: #bb9af7;
 }
 
+#custom-music {
+    color: #c0caf5;
+}
+
 #network {
     color: #b4f9f8;
 }


### PR DESCRIPTION
## Summary

- add an explicit foreground color for `#custom-music`
- keeps the existing mpv/playerctl widget command unchanged

## Notes

The music widget was only included in the shared background/padding selector. Other widgets define their own foreground colors, but `#custom-music` did not, so the text could render invisibly depending on inherited styling/theme state.