### PR TITLE
Add Hyprland shortcut for disliked music tracks

### DIFF
--- a/files/home/.config/hypr/adopted.d/dubnium.conf
+++ b/files/home/.config/hypr/adopted.d/dubnium.conf
@@ -180,6 +180,9 @@ bind = $mainMod, C, exec, $editor
 bind = $mainMod, V, exec, ~/.local/bin/dub-clipboard
 bind = $mainMod SHIFT, Escape, exec, ~/.local/bin/dub-session-reset
 
+# Music
+bind = $mainMod SHIFT, Delete, exec, ~/.local/bin/music-dislike
+
 # Tiling controls
 bind = $mainMod, S, layoutmsg, togglesplit
 bind = $mainMod, F, fullscreen

--- a/files/home/.config/hypr/adopted.d/technetium.conf
+++ b/files/home/.config/hypr/adopted.d/technetium.conf
@@ -184,6 +184,9 @@ bind = $mainMod, code:27, exec, wofi --show drun --style ~/.config/wofi/style.cs
 bind = $mainMod, code:33, pseudo,
 bind = $mainMod, J, layoutmsg, togglesplit
 
+# Music
+bind = $mainMod SHIFT, Delete, exec, ~/.local/bin/music-dislike
+
 # Focus
 bind = $mainMod, left, movefocus, l
 bind = $mainMod, right, movefocus, r


### PR DESCRIPTION
## Summary

- add a Hyprland-level `SUPER+SHIFT+Delete` shortcut for `music-dislike`
- apply the shortcut to both dubnium and technetium adopted Hyprland configs

## Rationale

The mpv input binding only works when an mpv window has focus. The default `music` launcher is audio-only, so there is no focused mpv window to receive `Shift+Delete`. A compositor-level shortcut makes the dislike workflow work while local music is playing in the background.

Plain `Shift+Delete` is intentionally avoided because it is a common app-level cut/delete shortcut.