### PR TITLE
Fix and scroll Waybar player text

### DIFF
--- a/files/home/.config/waybar/config-technetium.jsonc
+++ b/files/home/.config/waybar/config-technetium.jsonc
@@ -110,10 +110,10 @@
         "tooltip": true
     },
     "custom/music": {
-        "exec": "playerctl --player=mpv metadata --format '{{artist}} - {{title}}' 2>/dev/null || true",
-        "interval": 2,
+        "exec": "music-status",
+        "interval": 1,
+        "return-type": "json",
         "format": " {}",
-        "max-length": 36,
         "escape": true,
         "on-click": "playerctl --player=mpv play-pause",
         "on-click-right": "playerctl --player=mpv next",

--- a/files/home/.config/waybar/config.jsonc
+++ b/files/home/.config/waybar/config.jsonc
@@ -100,10 +100,10 @@
         "tooltip": true
     },
     "custom/music": {
-        "exec": "playerctl --player=mpv metadata --format '{{artist}} - {{title}}' 2>/dev/null || true",
-        "interval": 2,
+        "exec": "music-status",
+        "interval": 1,
+        "return-type": "json",
         "format": " {}",
-        "max-length": 36,
         "escape": true,
         "on-click": "playerctl --player=mpv play-pause",
         "on-click-right": "playerctl --player=mpv next",

--- a/files/home/.config/waybar/style.css
+++ b/files/home/.config/waybar/style.css
@@ -62,6 +62,11 @@ window#waybar {
     color: #bb9af7;
 }
 
+#custom-music,
+#custom-media {
+    color: #c0caf5;
+}
+
 #network {
     color: #b4f9f8;
 }

--- a/files/home/.local/bin/music-status
+++ b/files/home/.local/bin/music-status
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+status="$(playerctl --player=mpv status 2>/dev/null || true)"
+
+if [ -z "$status" ]; then
+  python3 - <<'PY'
+import json
+print(json.dumps({"text": "stopped", "alt": "stopped", "class": "stopped", "tooltip": "mpv music stopped"}))
+PY
+  exit 0
+fi
+
+artist="$(playerctl --player=mpv metadata xesam:artist 2>/dev/null || true)"
+title="$(playerctl --player=mpv metadata xesam:title 2>/dev/null || true)"
+url="$(playerctl --player=mpv metadata xesam:url 2>/dev/null || true)"
+
+python3 - "$status" "$artist" "$title" "$url" <<'PY'
+import json
+import os
+import sys
+from urllib.parse import unquote, urlparse
+
+status, artist, title, url = sys.argv[1:5]
+artist = artist.strip()
+title = title.strip()
+
+if artist and title:
+    text = f"{artist} - {title}"
+elif title:
+    text = title
+else:
+    parsed = urlparse(url)
+    if parsed.scheme == "file":
+        text = os.path.basename(unquote(parsed.path)) or "mpv music"
+    else:
+        text = "mpv music"
+
+tooltip_parts = [part for part in (artist, title) if part]
+tooltip = " - ".join(tooltip_parts) if tooltip_parts else text
+
+print(json.dumps({
+    "text": text,
+    "alt": status.lower(),
+    "class": status.lower(),
+    "tooltip": f"mpv: {tooltip}",
+}))
+PY

--- a/files/home/.local/bin/music-status
+++ b/files/home/.local/bin/music-status
@@ -19,6 +19,7 @@ python3 - "$status" "$artist" "$title" "$url" <<'PY'
 import json
 import os
 import sys
+import time
 from urllib.parse import unquote, urlparse
 
 status, artist, title, url = sys.argv[1:5]
@@ -26,23 +27,28 @@ artist = artist.strip()
 title = title.strip()
 
 if artist and title:
-    text = f"{artist} - {title}"
+    full_text = f"{artist} - {title}"
 elif title:
-    text = title
+    full_text = title
 else:
     parsed = urlparse(url)
     if parsed.scheme == "file":
-        text = os.path.basename(unquote(parsed.path)) or "mpv music"
+        full_text = os.path.basename(unquote(parsed.path)) or "mpv music"
     else:
-        text = "mpv music"
+        full_text = "mpv music"
 
-tooltip_parts = [part for part in (artist, title) if part]
-tooltip = " - ".join(tooltip_parts) if tooltip_parts else text
+width = 36
+if len(full_text) > width:
+    padded = f"{full_text}   •   "
+    offset = int(time.time()) % len(padded)
+    text = (padded + padded)[offset:offset + width]
+else:
+    text = full_text
 
 print(json.dumps({
     "text": text,
     "alt": status.lower(),
     "class": status.lower(),
-    "tooltip": f"mpv: {tooltip}",
+    "tooltip": f"mpv: {full_text}",
 }))
 PY

--- a/modules/home/hypr.nix
+++ b/modules/home/hypr.nix
@@ -43,6 +43,7 @@ let
     "dub-session-start"
     "dub-terminal"
     "dub-waybar-reload"
+    "music-status"
     "random-wallpaper"
     "random-quote"
   ];

--- a/modules/home/music.nix
+++ b/modules/home/music.nix
@@ -73,5 +73,10 @@ in
       source = ../../files/home/.local/bin/music-dislike;
       executable = true;
     };
+
+    home.file.".local/bin/music-status" = {
+      source = ../../files/home/.local/bin/music-status;
+      executable = true;
+    };
   };
 }

--- a/modules/home/music.nix
+++ b/modules/home/music.nix
@@ -73,10 +73,5 @@ in
       source = ../../files/home/.local/bin/music-dislike;
       executable = true;
     };
-
-    home.file.".local/bin/music-status" = {
-      source = ../../files/home/.local/bin/music-status;
-      executable = true;
-    };
   };
 }


### PR DESCRIPTION
Superseded by a clean replacement branch based on current `main`; this branch diverged before the Hyprland shortcut merge and GitHub marked it unmergeable.

Replacement: `fix/waybar-player-text-scroll`.