### PR TITLE
Fix and scroll Waybar player text

### DIFF
--- a/files/home/.config/waybar/config-technetium.jsonc
+++ b/files/home/.config/waybar/config-technetium.jsonc
@@ -110,10 +110,10 @@
         "tooltip": true
     },
     "custom/music": {
-        "exec": "playerctl --player=mpv metadata --format '{{artist}} - {{title}}' 2>/dev/null || true",
-        "interval": 2,
+        "exec": "music-status",
+        "interval": 1,
+        "return-type": "json",
         "format": " {}",
-        "max-length": 36,
         "escape": true,
         "on-click": "playerctl --player=mpv play-pause",
         "on-click-right": "playerctl --player=mpv next",

--- a/files/home/.config/waybar/config.jsonc
+++ b/files/home/.config/waybar/config.jsonc
@@ -100,10 +100,10 @@
         "tooltip": true
     },
     "custom/music": {
-        "exec": "playerctl --player=mpv metadata --format '{{artist}} - {{title}}' 2>/dev/null || true",
-        "interval": 2,
+        "exec": "music-status",
+        "interval": 1,
+        "return-type": "json",
         "format": " {}",
-        "max-length": 36,
         "escape": true,
         "on-click": "playerctl --player=mpv play-pause",
         "on-click-right": "playerctl --player=mpv next",

--- a/files/home/.config/waybar/style.css
+++ b/files/home/.config/waybar/style.css
@@ -62,7 +62,8 @@ window#waybar {
     color: #bb9af7;
 }
 
-#custom-music {
+#custom-music,
+#custom-media {
     color: #c0caf5;
 }
 

--- a/files/home/.local/bin/music-status
+++ b/files/home/.local/bin/music-status
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+status="$(playerctl --player=mpv status 2>/dev/null || true)"
+
+if [ -z "$status" ]; then
+  python3 - <<'PY'
+import json
+print(json.dumps({"text": "stopped", "alt": "stopped", "class": "stopped", "tooltip": "mpv music stopped"}))
+PY
+  exit 0
+fi
+
+artist="$(playerctl --player=mpv metadata xesam:artist 2>/dev/null || true)"
+title="$(playerctl --player=mpv metadata xesam:title 2>/dev/null || true)"
+url="$(playerctl --player=mpv metadata xesam:url 2>/dev/null || true)"
+
+python3 - "$status" "$artist" "$title" "$url" <<'PY'
+import json
+import os
+import sys
+import time
+from urllib.parse import unquote, urlparse
+
+status, artist, title, url = sys.argv[1:5]
+artist = artist.strip()
+title = title.strip()
+
+if artist and title:
+    full_text = f"{artist} - {title}"
+elif title:
+    full_text = title
+else:
+    parsed = urlparse(url)
+    if parsed.scheme == "file":
+        full_text = os.path.basename(unquote(parsed.path)) or "mpv music"
+    else:
+        full_text = "mpv music"
+
+width = 36
+if len(full_text) > width:
+    padded = f"{full_text}   •   "
+    offset = int(time.time()) % len(padded)
+    text = (padded + padded)[offset:offset + width]
+else:
+    text = full_text
+
+print(json.dumps({
+    "text": text,
+    "alt": status.lower(),
+    "class": status.lower(),
+    "tooltip": f"mpv: {full_text}",
+}))
+PY

--- a/modules/home/hypr.nix
+++ b/modules/home/hypr.nix
@@ -43,6 +43,7 @@ let
     "dub-session-start"
     "dub-terminal"
     "dub-waybar-reload"
+    "music-status"
     "random-wallpaper"
     "random-quote"
   ];


### PR DESCRIPTION
## Summary

- restore explicit foreground styling for both `#custom-music` and `#custom-media`
- add a managed `music-status` helper for the mpv Waybar widget
- make the mpv music widget use Waybar JSON output with tooltip/status metadata
- scroll long mpv artist/title/file-name text by rotating the visible window once per second
- apply the mpv widget change to both dubnium and technetium Waybar configs
- install `music-status` with the workstation/Waybar script set so Waybar profiles always have the helper

## Notes

Waybar custom modules do not provide a native marquee for arbitrary command text, so the scroll behavior is implemented by the helper returning a moving 36-character text window. The tooltip still shows the full title.

The helper also falls back to the decoded local file name when mpv metadata lacks artist/title tags.

Supersedes #90, which diverged from current `main`.