### PR TITLE
Fix Music Window desktop launcher

### DIFF
--- a/modules/home/music.nix
+++ b/modules/home/music.nix
@@ -6,6 +6,33 @@
 }:
 let
   cfg = config.dotfiles.music;
+
+  musicWindow = pkgs.writeShellScript "music-window" ''
+    set -euo pipefail
+
+    music_dir="''${MPV_MUSIC_DIR:-''${DUBNIUM_MUSIC_DIR:-$HOME/Music}}"
+
+    mpv_music_window_args=(
+      --force-window=yes
+      --audio-display=embedded-first
+      --loop-playlist=inf
+      --save-position-on-quit
+    )
+
+    if [ "$#" -gt 0 ]; then
+      exec ${pkgs.mpv}/bin/mpv "''${mpv_music_window_args[@]}" "$@"
+    fi
+
+    if [ ! -d "$music_dir" ]; then
+      ${pkgs.libnotify}/bin/notify-send "Music Window" "Music directory not found: $music_dir" || true
+      exit 1
+    fi
+
+    exec ${pkgs.mpv}/bin/mpv \
+      "''${mpv_music_window_args[@]}" \
+      --shuffle \
+      "$music_dir"
+  '';
 in
 {
   options.dotfiles.music = {
@@ -47,7 +74,7 @@ in
       name = "Music Window";
       genericName = "Music Player";
       comment = "Open the local music library in mpv's graphical window";
-      exec = "${config.home.homeDirectory}/.local/bin/music-window";
+      exec = "${musicWindow}";
       terminal = false;
       categories = [ "Audio" "Music" "Player" ];
     };
@@ -60,7 +87,7 @@ in
     };
 
     home.file.".local/bin/music-window" = {
-      source = ../../files/home/.local/bin/music-window;
+      source = musicWindow;
       executable = true;
     };
 

--- a/modules/home/music.nix
+++ b/modules/home/music.nix
@@ -10,7 +10,7 @@ let
   musicWindow = pkgs.writeShellScript "music-window" ''
     set -euo pipefail
 
-    music_dir="''${MPV_MUSIC_DIR:-''${DUBNIUM_MUSIC_DIR:-$HOME/Music}}"
+    music_dir="''${MPV_MUSIC_DIR:-''${DUBNIUM_MUSIC_DIR:-${cfg.musicDirectory}}}"
 
     mpv_music_window_args=(
       --force-window=yes


### PR DESCRIPTION
## Summary

- generate the managed `music-window` helper from Home Manager
- make the helper call `${pkgs.mpv}/bin/mpv` directly instead of relying on launcher PATH
- point the desktop entry `Exec` at the generated Nix-store helper
- show a desktop notification if the configured music directory is missing

## Rationale

The `Music Window` desktop entry used an absolute `~/.local/bin/music-window` path, but the script still called plain `mpv`. Launchers like `wofi --show drun` may run desktop entries with a narrower environment than an interactive shell, so `mpv` can be missing from PATH and the launcher appears to do nothing.