### PR TITLE
Add Beets current-track retag shortcut

### DIFF
--- a/files/home/.config/hypr/adopted.d/dubnium.conf
+++ b/files/home/.config/hypr/adopted.d/dubnium.conf
@@ -182,6 +182,7 @@ bind = $mainMod SHIFT, Escape, exec, ~/.local/bin/dub-session-reset
 
 # Music
 bind = $mainMod SHIFT, Delete, exec, ~/.local/bin/music-dislike
+bind = $mainMod SHIFT, M, exec, ~/.local/bin/music-retag-current
 
 # Tiling controls
 bind = $mainMod, S, layoutmsg, togglesplit

--- a/files/home/.config/hypr/adopted.d/technetium.conf
+++ b/files/home/.config/hypr/adopted.d/technetium.conf
@@ -186,6 +186,7 @@ bind = $mainMod, J, layoutmsg, togglesplit
 
 # Music
 bind = $mainMod SHIFT, Delete, exec, ~/.local/bin/music-dislike
+bind = $mainMod SHIFT, M, exec, ~/.local/bin/music-retag-current
 
 # Focus
 bind = $mainMod, left, movefocus, l

--- a/files/home/.local/bin/music-retag-current
+++ b/files/home/.local/bin/music-retag-current
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+notify() {
+  if command -v notify-send >/dev/null 2>&1; then
+    notify-send "Music Retag" "$1" || true
+  else
+    printf 'music-retag-current: %s\n' "$1" >&2
+  fi
+}
+
+uri="$(playerctl --player=mpv metadata xesam:url 2>/dev/null || true)"
+
+if [ -z "$uri" ]; then
+  notify "No mpv track URL found"
+  exit 1
+fi
+
+case "$uri" in
+  file://*) ;;
+  *)
+    notify "Refusing non-local track"
+    exit 1
+    ;;
+esac
+
+path="$(python3 - "$uri" <<'PY'
+import sys
+from urllib.parse import unquote, urlparse
+
+parsed = urlparse(sys.argv[1])
+if parsed.scheme != "file":
+    raise SystemExit(1)
+print(unquote(parsed.path))
+PY
+)"
+
+if [ ! -f "$path" ]; then
+  notify "Current track is not a file: $path"
+  exit 1
+fi
+
+exec dub-terminal --title "beets retag" -e sh -lc '
+  set -eu
+  printf "Retagging current track with Beets:\n%s\n\n" "$1"
+  printf "This runs: beet import --single <current-file>\n\n"
+  beet import --single "$1"
+  printf "\nDone. Press Enter to close."
+  read _
+' sh "$path"

--- a/modules/home/music.nix
+++ b/modules/home/music.nix
@@ -47,6 +47,7 @@ in
 
   config = lib.mkIf cfg.enable {
     home.packages = with pkgs; [
+      beets
       easyeffects
       playerctl
       python3
@@ -98,6 +99,11 @@ in
 
     home.file.".local/bin/music-dislike" = {
       source = ../../files/home/.local/bin/music-dislike;
+      executable = true;
+    };
+
+    home.file.".local/bin/music-retag-current" = {
+      source = ../../files/home/.local/bin/music-retag-current;
       executable = true;
     };
   };


### PR DESCRIPTION
## Summary

- install `beets` with the optional music tooling profile
- add `music-retag-current` helper for the current mpv track
- decode the current local file path from mpv MPRIS metadata
- refuse missing, non-local, or non-file tracks
- open an interactive terminal running `beet import --single <current-file>`
- add `SUPER+SHIFT+M` Hyprland shortcuts on dubnium and technetium

## Notes

The helper intentionally opens an interactive terminal rather than doing a silent one-keystroke retag. Beets matching can require confirmation, and automatic metadata changes are risky when files are already poorly tagged.