### PR TITLE
Fix Waybar music status command

### DIFF
--- a/files/home/.config/waybar/config-technetium.jsonc
+++ b/files/home/.config/waybar/config-technetium.jsonc
@@ -110,7 +110,7 @@
         "tooltip": true
     },
     "custom/music": {
-        "exec": "music-status",
+        "exec": "~/.local/bin/music-status",
         "interval": 1,
         "return-type": "json",
         "format": " {}",

--- a/files/home/.config/waybar/config.jsonc
+++ b/files/home/.config/waybar/config.jsonc
@@ -155,7 +155,7 @@
         "exec": "playerctl -a metadata --format '{\"text\": \"{{artist}} - {{title}}\", \"alt\": \"{{status}}\", \"class\": \"{{status}}\"}' --follow"
     },
     "custom/power": {
-        "format": "⏻ " ,
+        "format": "⏻ ",
         "on-click": "wlogout"
     }
 }

--- a/files/home/.config/waybar/config.jsonc
+++ b/files/home/.config/waybar/config.jsonc
@@ -100,7 +100,7 @@
         "tooltip": true
     },
     "custom/music": {
-        "exec": "music-status",
+        "exec": "~/.local/bin/music-status",
         "interval": 1,
         "return-type": "json",
         "format": " {}",
@@ -155,7 +155,7 @@
         "exec": "playerctl -a metadata --format '{\"text\": \"{{artist}} - {{title}}\", \"alt\": \"{{status}}\", \"class\": \"{{status}}\"}' --follow"
     },
     "custom/power": {
-        "format": "⏻ ",
+        "format": "⏻ " ,
         "on-click": "wlogout"
     }
 }

--- a/modules/home/hypr.nix
+++ b/modules/home/hypr.nix
@@ -73,6 +73,8 @@ in
   config = lib.mkIf config.dotfiles.profiles.workstation.enable {
     home.packages = [
       pkgs.lm_sensors
+      pkgs.playerctl
+      pkgs.python3
       pkgs.variety
     ];
 


### PR DESCRIPTION
## Summary

- run `~/.local/bin/music-status` from the Waybar mpv widget instead of relying on `music-status` being in PATH
- apply the fix to both dubnium and technetium Waybar configs

## Rationale

The music widget configuration and styling are still present, and `music-status` is managed by Home Manager. If Waybar starts with a narrower environment, `music-status` may not be resolvable by name and the custom module disappears. Using the managed helper path avoids that launcher/session PATH dependency.