### PR TITLE
fix(android): expose Android SDK command-line tools

### DIFF
--- a/files/home/.config/zsh/config.d/android
+++ b/files/home/.config/zsh/config.d/android
@@ -1,2 +1,2 @@
-export ANDROID_HOME=$HOME/.local/share/android/sdk
-export PATH=$PATH:$ANDROID_HOME/platform-tools:$ANDROID_HOME/build-tools:$ANDROID_HOME/emulator
+export ANDROID_HOME="$HOME/.local/share/android/sdk"
+export PATH="$PATH:$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/tools/bin:$ANDROID_HOME/platform-tools:$ANDROID_HOME/emulator"


### PR DESCRIPTION
## Summary

- add the Android SDK `cmdline-tools/latest/bin` directory to `PATH`
- retain the legacy `tools/bin` location for SDKs that still provide the `android` command
- keep `platform-tools` and `emulator` available
- remove the ineffective unversioned `build-tools` path

## Notes

Modern Android SDKs provide `sdkmanager` and `avdmanager` under `cmdline-tools/latest/bin`; the legacy `android` executable is only available when an older SDK tools installation provides it under `tools/bin`.
