### PR TITLE
Fix user-local profile override priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Create the ignored local selector from the tracked example:
 cp home/USERNAME/user.example.nix home/USERNAME/user.local.nix
 ```
 
-`user.local.nix` owns local, non-secret user-wide program/capability selections and Git identity. Host constraints, hardware/display details, host paths, and role-specific differences remain in tracked profiles.
+`user.local.nix` owns local, non-secret portable user selections and Git identity. It may be sparse, containing only deliberate overrides, or complete, explicitly declaring every portable user-facing option. Tracked profiles provide portable defaults with `lib.mkDefault`; host identity, role/capability constraints, adopted desktop profiles, hardware/display details, and machine-specific paths remain authoritative in tracked profiles.
 
 Because Git-backed flakes exclude ignored files, commands that must include `user.local.nix` must be run from the repository root with an explicit `path:` flake reference:
 
@@ -51,9 +51,9 @@ Do not put secrets in `user.local.nix`. A `path:` flake source is copied into th
 The configuration contract is:
 
 ```text
-user.local.nix selects local desired capabilities
+tracked profiles provide host constraints and portable defaults
+user.local.nix overrides portable user selections
 modules resolve implementation dependencies
-tracked host profiles constrain what each machine supports
 ```
 
 Every user-facing program should eventually have an explicit enable flag. Internal runtime dependencies remain owned by the feature module; shared tools and optional integrations are modeled explicitly and validated.

--- a/home/ryjen/profiles/dubnium.nix
+++ b/home/ryjen/profiles/dubnium.nix
@@ -10,10 +10,10 @@
   dotfiles.profiles.micrantha.enable = lib.mkDefault false;
   dotfiles.profiles.office.enable = lib.mkDefault true;
   dotfiles.opsCadence.enable = lib.mkDefault true;
-  dotfiles.hypr.adoptedProfile = lib.mkDefault "dubnium";
+  dotfiles.hypr.adoptedProfile = "dubnium";
 
   dotfiles.music = {
     enable = lib.mkDefault true;
-    musicDirectory = lib.mkDefault "/mnt/isotope/Music";
+    musicDirectory = "/mnt/isotope/Music";
   };
 }

--- a/home/ryjen/profiles/dubnium.nix
+++ b/home/ryjen/profiles/dubnium.nix
@@ -1,19 +1,19 @@
-{ ... }:
+{ lib, ... }:
 {
   imports = [
     ./workstation.nix
   ];
 
   dotfiles.host.name = "dubnium";
-  dotfiles.profiles.browser.enable = true;
-  dotfiles.profiles.android.enable = false;
-  dotfiles.profiles.micrantha.enable = false;
-  dotfiles.profiles.office.enable = true;
-  dotfiles.opsCadence.enable = true;
-  dotfiles.hypr.adoptedProfile = "dubnium";
+  dotfiles.profiles.browser.enable = lib.mkDefault true;
+  dotfiles.profiles.android.enable = lib.mkDefault false;
+  dotfiles.profiles.micrantha.enable = lib.mkDefault false;
+  dotfiles.profiles.office.enable = lib.mkDefault true;
+  dotfiles.opsCadence.enable = lib.mkDefault true;
+  dotfiles.hypr.adoptedProfile = lib.mkDefault "dubnium";
 
   dotfiles.music = {
-    enable = true;
-    musicDirectory = "/mnt/isotope/Music";
+    enable = lib.mkDefault true;
+    musicDirectory = lib.mkDefault "/mnt/isotope/Music";
   };
 }

--- a/home/ryjen/profiles/graphical.nix
+++ b/home/ryjen/profiles/graphical.nix
@@ -1,5 +1,5 @@
-{ ... }:
+{ lib, ... }:
 {
   dotfiles.host.graphical.enable = true;
-  dotfiles.graphical.keyring.enable = true;
+  dotfiles.graphical.keyring.enable = lib.mkDefault true;
 }

--- a/home/ryjen/profiles/technetium.nix
+++ b/home/ryjen/profiles/technetium.nix
@@ -5,10 +5,10 @@
   ];
 
   dotfiles.host.name = "technetium";
-  dotfiles.profiles.browser.enable = true;
-  dotfiles.profiles.android.enable = false;
-  dotfiles.profiles.micrantha.enable = false;
-  dotfiles.hypr.adoptedProfile = "technetium";
+  dotfiles.profiles.browser.enable = lib.mkDefault true;
+  dotfiles.profiles.android.enable = lib.mkDefault false;
+  dotfiles.profiles.micrantha.enable = lib.mkDefault false;
+  dotfiles.hypr.adoptedProfile = lib.mkDefault "technetium";
 
   xdg.configFile."waybar/config.jsonc".source =
     lib.mkForce ../../../files/home/.config/waybar/config-technetium.jsonc;

--- a/home/ryjen/profiles/technetium.nix
+++ b/home/ryjen/profiles/technetium.nix
@@ -8,7 +8,7 @@
   dotfiles.profiles.browser.enable = lib.mkDefault true;
   dotfiles.profiles.android.enable = lib.mkDefault false;
   dotfiles.profiles.micrantha.enable = lib.mkDefault false;
-  dotfiles.hypr.adoptedProfile = lib.mkDefault "technetium";
+  dotfiles.hypr.adoptedProfile = "technetium";
 
   xdg.configFile."waybar/config.jsonc".source =
     lib.mkForce ../../../files/home/.config/waybar/config-technetium.jsonc;

--- a/home/ryjen/profiles/workstation.nix
+++ b/home/ryjen/profiles/workstation.nix
@@ -1,12 +1,12 @@
-{ ... }:
+{ lib, ... }:
 {
   imports = [
     ./graphical.nix
   ];
 
   dotfiles.host.role = "workstation";
-  dotfiles.profiles.workstation.enable = true;
-  dotfiles.agents.hermes.enable = true;
-  dotfiles.agents.antigravity.enable = true;
-  dotfiles.headroom.proxy.enable = true;
+  dotfiles.profiles.workstation.enable = lib.mkDefault true;
+  dotfiles.agents.hermes.enable = lib.mkDefault true;
+  dotfiles.agents.antigravity.enable = lib.mkDefault true;
+  dotfiles.headroom.proxy.enable = lib.mkDefault true;
 }

--- a/home/ryjen/profiles/workstation.nix
+++ b/home/ryjen/profiles/workstation.nix
@@ -5,7 +5,7 @@
   ];
 
   dotfiles.host.role = "workstation";
-  dotfiles.profiles.workstation.enable = lib.mkDefault true;
+  dotfiles.profiles.workstation.enable = true;
   dotfiles.agents.hermes.enable = lib.mkDefault true;
   dotfiles.agents.antigravity.enable = lib.mkDefault true;
   dotfiles.headroom.proxy.enable = lib.mkDefault true;

--- a/home/ryjen/user.example.nix
+++ b/home/ryjen/user.example.nix
@@ -2,9 +2,10 @@
 # Use a path flake so ignored files are included:
 #   home-manager switch --flake "path:$PWD#ryjen@dubnium"
 #
-# This file is the canonical catalog of supported local selections. Keep every
-# user-facing toggle here when options are added, renamed, or removed.
-{ config, ... }:
+# This file is the canonical catalog of supported portable user selections.
+# Keep only deliberate overrides active. Uncomment every portable option only
+# when maintaining a complete user-level desired-state file.
+{ ... }:
 {
   # Personal identity. Replace both placeholders together in user.local.nix.
   # The Git module enforces user.useConfigOnly globally.
@@ -13,69 +14,44 @@
     userEmail = "you@example.com";
   };
 
-  # Independently selectable agents.
-  dotfiles.agents = {
-    hermes.enable = false;
-    antigravity.enable = false;
-  };
+  # Portable overrides. Tracked profiles provide defaults through mkDefault.
+  # dotfiles.agents.hermes.enable = false;
+  # dotfiles.agents.antigravity.enable = false;
 
-  # Tool environments.
-  dotfiles.uv = {
-    enable = false;
-    toolsFile = ".config/uv/tools.toml";
-  };
+  # dotfiles.uv.enable = false;
+  # dotfiles.uv.toolsFile = ".config/uv/tools.toml";
 
-  dotfiles.npm = {
-    enable = false;
-    prefix = "${config.home.homeDirectory}/.local/share/npm";
-    globalPackagesFile = ".config/npm/global-packages.txt";
-  };
+  # dotfiles.npm.enable = false;
+  # dotfiles.npm.prefix = "${config.home.homeDirectory}/.local/share/npm";
+  # dotfiles.npm.globalPackagesFile = ".config/npm/global-packages.txt";
 
-  dotfiles.pip = {
-    enable = false;
-    prefix = "${config.home.homeDirectory}/.local/share/pip";
-    globalPackagesFile = ".config/pip/global-packages.txt";
-  };
+  # dotfiles.pip.enable = false;
+  # dotfiles.pip.prefix = "${config.home.homeDirectory}/.local/share/pip";
+  # dotfiles.pip.globalPackagesFile = ".config/pip/global-packages.txt";
 
-  # User-facing capabilities.
-  dotfiles.music = {
-    enable = false;
-    musicDirectory = "${config.home.homeDirectory}/Music";
-  };
+  # dotfiles.music.enable = false;
+  # dotfiles.grimblast.enable = false;
+  # dotfiles.graphical.keyring.enable = false;
 
-  dotfiles.grimblast.enable = false;
-  dotfiles.graphical.keyring.enable = false;
+  # dotfiles.headroom.proxy.enable = false;
+  # dotfiles.headroom.proxy.host = "127.0.0.1";
+  # dotfiles.headroom.proxy.port = 8787;
+  # dotfiles.headroom.proxy.package = "${config.home.homeDirectory}/.local/libexec/headroom-proxy";
 
-  dotfiles.headroom.proxy = {
-    enable = false;
-    host = "127.0.0.1";
-    port = 8787;
-    package = "${config.home.homeDirectory}/.local/libexec/headroom-proxy";
-  };
-
-  dotfiles.opsCadence = {
-    enable = false;
-    timers.enable = true;
-  };
+  # dotfiles.opsCadence.enable = false;
+  # dotfiles.opsCadence.timers.enable = true;
 
   # Current grouped/profile selections. These remain listed until migrated to
   # stable tool, feature, desktop, service, or integration namespaces.
-  dotfiles.profiles = {
-    android.enable = false;
-    browser.enable = false;
-    micrantha.enable = false;
-    office.enable = false;
-    workstation.enable = false;
-  };
-
-  # Non-secret local profile choices.
-  dotfiles.alacritty.adoptedProfile = "empty"; # empty | dubnium
-  dotfiles.hypr.adoptedProfile = "empty"; # empty | dubnium | technetium
+  # dotfiles.profiles.android.enable = false;
+  # dotfiles.profiles.browser.enable = false;
+  # dotfiles.profiles.micrantha.enable = false;
+  # dotfiles.profiles.office.enable = false;
 
   # Optional runtime path containing a GPG fingerprint. Do not place the key
   # itself or other secret material in this file.
-  dotfiles.gpg.defaultKeyFile = null;
+  # dotfiles.gpg.defaultKeyFile = null;
 
-  # Host capability options are intentionally absent. They remain in tracked
-  # profiles because they describe machine support rather than user choice.
+  # Host identity, role/capability options, adopted desktop profiles, and
+  # machine-specific paths intentionally remain in tracked host profiles.
 }

--- a/home/ryjen/user.example.nix
+++ b/home/ryjen/user.example.nix
@@ -5,7 +5,7 @@
 # This file is the canonical catalog of supported portable user selections.
 # Keep only deliberate overrides active. Uncomment every portable option only
 # when maintaining a complete user-level desired-state file.
-{ ... }:
+{ config, ... }:
 {
   # Personal identity. Replace both placeholders together in user.local.nix.
   # The Git module enforces user.useConfigOnly globally.


### PR DESCRIPTION
## Summary

- convert user-selectable Dubnium and Technetium profile values to `lib.mkDefault`
- allow workstation agent, proxy, and capability selections to be overridden by `user.local.nix`
- retain hard host capability assignments such as host identity, graphical support, and the Technetium Waybar constraint

## Root cause

The tracked host profiles and ignored `user.local.nix` assigned the same options at equal Nix module priority. Enabling Micrantha locally therefore conflicted with the tracked Dubnium default of `false`, preventing `system.build.toplevel` from evaluating.

## Impact

Local Git identity and capability selections can now be included through the path-backed flake without colliding with tracked profile defaults.

## Validation

- inspected the resulting branch content for all four profile files
- preserved `lib.mkForce` only for the Technetium-specific Waybar source
- no local Nix evaluator is available through the connector environment; the affected expression is a direct priority-only change