### PR TITLE
Restore configctl local configuration layers

### DIFF
--- a/contracts/configctl/README.md
+++ b/contracts/configctl/README.md
@@ -95,6 +95,7 @@ Important constraints:
 
 | Tool | Manifest | Strategy | Status | Current owner | Target owner |
 | --- | --- | --- | --- | --- | --- |
+| Git | `apps/git.toml` | native include | active | Home Manager | Home Manager |
 | Hyprland | `apps/hypr.toml` | native include | active | Home Manager | Home Manager |
 | Zsh | `apps/zsh.toml` | native include | active | Home Manager | Home Manager |
 | Hyprpaper | `apps/hyprpaper.toml` | compose | planned | Home Manager | configctl |

--- a/contracts/configctl/apps/git.toml
+++ b/contracts/configctl/apps/git.toml
@@ -1,0 +1,54 @@
+schema_version = 1
+tool = "git"
+owner = "dotfiles"
+profile = "all"
+status = "active"
+strategy = "native-include"
+current_runtime_owner = "home-manager"
+target_runtime_owner = "home-manager"
+executor_may_validate = true
+executor_may_adopt = true
+executor_may_write_outputs = false
+renderer_required = false
+description = "Git loads unmanaged local configuration and configctl-managed include fragments from the Home Manager-generated global config."
+
+[layout]
+root = "~/.config/git"
+standard = "configctl-v1"
+source_inputs = [
+  "modules/home/git.nix"
+]
+runtime_outputs = [
+  "config"
+]
+local = [
+  "local.conf"
+]
+custom = [
+  "conf.d/*"
+]
+adopted = []
+runtime_includes = [
+  "includes.conf",
+  "local.conf",
+  "conf.d/*"
+]
+auxiliary_outputs = [
+  "commit-message"
+]
+
+[adoption]
+state_path = "~/.local/state/configctl/adoptions/git.toml"
+hash_algorithm = "sha256"
+mode = "review-gated"
+ignore = [
+  "local"
+]
+
+[validation]
+must_not_manage = [
+  "local"
+]
+must_exist_or_be_creatable = [
+  "custom"
+]

--- a/contracts/configctl/apps/git.toml
+++ b/contracts/configctl/apps/git.toml
@@ -10,7 +10,7 @@ executor_may_validate = true
 executor_may_adopt = true
 executor_may_write_outputs = false
 renderer_required = false
-description = "Git loads unmanaged local configuration and configctl-managed include fragments from the Home Manager-generated global config."
+description = "Home Manager owns Git's root config, which loads a configctl-maintained include index plus an unmanaged local override file."
 
 [layout]
 root = "~/.config/git"
@@ -30,10 +30,10 @@ custom = [
 adopted = []
 runtime_includes = [
   "includes.conf",
-  "local.conf",
-  "conf.d/*"
+  "local.conf"
 ]
 auxiliary_outputs = [
+  "includes.conf",
   "commit-message"
 ]
 

--- a/modules/home/git.nix
+++ b/modules/home/git.nix
@@ -22,12 +22,17 @@ in
       "*.log"
       "**/.claude/settings.local.json"
     ];
-    includes = lib.optionals micranthaEnabled [
-      {
-        condition = "gitdir:~/**/micrantha/**";
-        path = "~/.config/git/conf.d/micrantha";
-      }
-    ];
+    includes =
+      [
+        { path = "~/.config/git/includes.conf"; }
+        { path = "~/.config/git/local.conf"; }
+      ]
+      ++ lib.optionals micranthaEnabled [
+        {
+          condition = "gitdir:~/**/micrantha/**";
+          path = "~/.config/git/conf.d/micrantha";
+        }
+      ];
     settings = {
       alias = {
         ff = "flow feature";

--- a/modules/home/hypr.nix
+++ b/modules/home/hypr.nix
@@ -137,6 +137,14 @@ in
 
     home.file = managedFiles;
 
+    home.activation.ensureHyprLocalConfig = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      local_config="$HOME/.config/hypr/local.conf"
+      if [ ! -e "$local_config" ]; then
+        ${pkgs.coreutils}/bin/mkdir -p "$(${pkgs.coreutils}/bin/dirname "$local_config")"
+        ${pkgs.coreutils}/bin/printf '%s\n' '# Place host-local or user overrides here.' > "$local_config"
+      fi
+    '';
+
     home.activation.configureVarietyWallpaperFolders = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
       variety_config="$HOME/.config/variety/variety.conf"
       variety_downloads="$HOME/Pictures/wallpaper/variety/downloaded"

--- a/modules/home/hypr.nix
+++ b/modules/home/hypr.nix
@@ -94,12 +94,6 @@ in
       source = ~/.config/hypr/custom.d/*.conf
     '';
 
-    # Hyprland sources local.conf and custom.d/*.conf; ensure local.conf exists
-    # so Hyprland does not emit a globbing/missing-file error on reload.
-    xdg.configFile."hypr/local.conf".text = ''
-      # Place host-local or user overrides here.
-    '';
-
     xdg.configFile."hypr/adopted.d/machine.conf".source =
       adoptedProfiles.${config.dotfiles.hypr.adoptedProfile};
     xdg.configFile."hypr/custom.d/00-empty.conf".source =


### PR DESCRIPTION
## Summary

- restore Git's native include chain for `~/.config/git/includes.conf` and `~/.config/git/local.conf`
- keep the Micrantha conditional include after the global/local layers
- stop Home Manager from owning `~/.config/hypr/local.conf`
- add an active Git native-include configctl contract
- document Git in the configctl coverage table

## Root cause

The Home Manager Git migration regenerated the global Git config without carrying forward the configctl include paths. Hyprland retained the include directive for `local.conf`, but Home Manager also generated the file, violating the configctl rule that `local.*` escape hatches remain unmanaged.

## Audit

- Git: broken include chain; fixed
- Hyprland: local include present, but local file incorrectly Home Manager-owned; fixed
- Zsh: `local.zsh` and `config.d/*` include chain remains intact
- Hyprpaper, Mako, Eww, and Waybar are planned compose contracts and remain intentionally Home Manager-owned until a renderer exists

## Validation

- reviewed all active native-include app contracts against their Home Manager modules
- confirmed Git include precedence is `includes.conf`, then `local.conf`, then repository-conditional Micrantha config
- confirmed no active Zsh regression
- the existing verifier validates init contracts only; the new app contract is declarative policy and does not affect that check