### PR TITLE
Start music from Waybar click

### DIFF
--- a/files/home/.config/waybar/config-technetium.jsonc
+++ b/files/home/.config/waybar/config-technetium.jsonc
@@ -113,7 +113,7 @@
         "exec": "~/.local/bin/music-status",
         "interval": 1,
         "return-type": "json",
-        "format": " {}",
+        "format": "{}",
         "escape": true,
         "on-click": "~/.local/bin/music-toggle",
         "on-click-right": "playerctl --player=mpv next",

--- a/files/home/.config/waybar/config-technetium.jsonc
+++ b/files/home/.config/waybar/config-technetium.jsonc
@@ -115,7 +115,7 @@
         "return-type": "json",
         "format": " {}",
         "escape": true,
-        "on-click": "playerctl --player=mpv play-pause",
+        "on-click": "~/.local/bin/music-toggle",
         "on-click-right": "playerctl --player=mpv next",
         "on-click-middle": "playerctl --player=mpv previous",
         "on-click-backward": "music-eq",

--- a/files/home/.config/waybar/config.jsonc
+++ b/files/home/.config/waybar/config.jsonc
@@ -105,7 +105,7 @@
         "return-type": "json",
         "format": " {}",
         "escape": true,
-        "on-click": "playerctl --player=mpv play-pause",
+        "on-click": "~/.local/bin/music-toggle",
         "on-click-right": "playerctl --player=mpv next",
         "on-click-middle": "playerctl --player=mpv previous",
         "on-click-backward": "music-eq",

--- a/files/home/.config/waybar/config.jsonc
+++ b/files/home/.config/waybar/config.jsonc
@@ -103,7 +103,7 @@
         "exec": "~/.local/bin/music-status",
         "interval": 1,
         "return-type": "json",
-        "format": " {}",
+        "format": "{}",
         "escape": true,
         "on-click": "~/.local/bin/music-toggle",
         "on-click-right": "playerctl --player=mpv next",

--- a/files/home/.local/bin/music-toggle
+++ b/files/home/.local/bin/music-toggle
@@ -5,4 +5,8 @@ if playerctl --player=mpv status >/dev/null 2>&1; then
   exec playerctl --player=mpv play-pause
 fi
 
-exec music
+if command -v music >/dev/null 2>&1; then
+  exec music
+fi
+
+exit 0

--- a/files/home/.local/bin/music-toggle
+++ b/files/home/.local/bin/music-toggle
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if playerctl --player=mpv status >/dev/null 2>&1; then
+  exec playerctl --player=mpv play-pause
+fi
+
+exec music

--- a/modules/home/hypr.nix
+++ b/modules/home/hypr.nix
@@ -44,6 +44,7 @@ let
     "dub-terminal"
     "dub-waybar-reload"
     "music-status"
+    "music-toggle"
     "random-wallpaper"
     "random-quote"
   ];

--- a/modules/home/music.nix
+++ b/modules/home/music.nix
@@ -96,11 +96,6 @@ in
       executable = true;
     };
 
-    home.file.".local/bin/music-toggle" = {
-      source = ../../files/home/.local/bin/music-toggle;
-      executable = true;
-    };
-
     home.file.".local/bin/music-eq" = {
       source = ../../files/home/.local/bin/music-eq;
       executable = true;

--- a/modules/home/music.nix
+++ b/modules/home/music.nix
@@ -96,6 +96,11 @@ in
       executable = true;
     };
 
+    home.file.".local/bin/music-toggle" = {
+      source = ../../files/home/.local/bin/music-toggle;
+      executable = true;
+    };
+
     home.file.".local/bin/music-eq" = {
       source = ../../files/home/.local/bin/music-eq;
       executable = true;


### PR DESCRIPTION
## Summary

The requested Waybar music behavior is now present on `main`:

- left-click toggles an existing MPV player
- left-click starts the background music player when MPV is absent
- play/pause state and elapsed/total time are exposed by `music-status`
- broken static music glyphs were removed from both Waybar configurations
- `music-toggle` is installed with the workstation/Waybar profile and safely no-ops when the optional music launcher is unavailable

This PR became unmergeable because its earlier changes were already applied directly to `main`. The remaining review finding was fixed on `main` in commits `0dcf275962736f58250d4f2e3a5d2fde8a8ddbbc` and `45680d2c577328be6d0142cae6a3cc7990fd4bd3`, so the PR is closed as superseded rather than force-merged.