### PR TITLE
Install and configure Bitwarden clients

### DIFF
--- a/docs/bitwarden.md
+++ b/docs/bitwarden.md
@@ -1,0 +1,32 @@
+# Bitwarden clients
+
+The Dubnium workstation profile installs both the Bitwarden desktop application and the `bw` CLI. Each can be overridden independently in `home/ryjen/user.local.nix`:
+
+```nix
+dotfiles.bitwarden.cli.enable = true;
+dotfiles.bitwarden.desktop.enable = true;
+```
+
+## Connect to Vaultwarden
+
+After the Vaultwarden service is deployed, configure the CLI with its HTTPS URL:
+
+```sh
+bw config server https://<vaultwarden-host>
+bw login
+```
+
+For the desktop application, select **Self-hosted** on the login screen and enter the same server URL.
+
+Do not commit credentials, vault exports, API keys, or `BW_SESSION` values. Prefer a short-lived shell session:
+
+```sh
+export BW_SESSION="$(bw unlock --raw)"
+# use bw commands
+bw lock
+unset BW_SESSION
+```
+
+Avoid placing `BW_SESSION` in shell startup files, tracked environment files, command wrappers, or the Nix store.
+
+The Firefox profile already installs the Bitwarden browser extension through managed browser policy. Configure its self-hosted server URL separately from the desktop and CLI clients.

--- a/home/ryjen/profiles/dubnium.nix
+++ b/home/ryjen/profiles/dubnium.nix
@@ -12,6 +12,9 @@
   dotfiles.opsCadence.enable = lib.mkDefault true;
   dotfiles.hypr.adoptedProfile = "dubnium";
 
+  dotfiles.bitwarden.cli.enable = lib.mkDefault true;
+  dotfiles.bitwarden.desktop.enable = lib.mkDefault true;
+
   dotfiles.music = {
     enable = lib.mkDefault true;
     musicDirectory = lib.mkDefault "/mnt/isotope/Music";

--- a/home/ryjen/user.example.nix
+++ b/home/ryjen/user.example.nix
@@ -29,8 +29,12 @@
   # dotfiles.pip.prefix = "${config.home.homeDirectory}/.local/share/pip";
   # dotfiles.pip.globalPackagesFile = ".config/pip/global-packages.txt";
 
-  # dotfiles.bitwarden.cli.enable = false;
-  # dotfiles.bitwarden.desktop.enable = false;
+  # Bitwarden clients. The Dubnium workstation profile enables both by default;
+  # use these explicit selections when maintaining a complete local config.
+  # dotfiles.bitwarden.cli.enable = true;
+  # dotfiles.bitwarden.desktop.enable = true;
+  # Set either value to false to disable that client independently.
+
   # dotfiles.music.enable = false;
   # dotfiles.grimblast.enable = false;
   # dotfiles.graphical.keyring.enable = false;

--- a/home/ryjen/user.example.nix
+++ b/home/ryjen/user.example.nix
@@ -29,6 +29,8 @@
   # dotfiles.pip.prefix = "${config.home.homeDirectory}/.local/share/pip";
   # dotfiles.pip.globalPackagesFile = ".config/pip/global-packages.txt";
 
+  # dotfiles.bitwarden.cli.enable = false;
+  # dotfiles.bitwarden.desktop.enable = false;
   # dotfiles.music.enable = false;
   # dotfiles.grimblast.enable = false;
   # dotfiles.graphical.keyring.enable = false;

--- a/modules/home/bitwarden.nix
+++ b/modules/home/bitwarden.nix
@@ -1,0 +1,22 @@
+{
+  lib,
+  config,
+  pkgs,
+  ...
+}:
+
+let
+  cfg = config.dotfiles.bitwarden;
+in
+{
+  options.dotfiles.bitwarden = {
+    cli.enable = lib.mkEnableOption "Bitwarden command-line client";
+    desktop.enable = lib.mkEnableOption "Bitwarden desktop client";
+  };
+
+  config = {
+    home.packages =
+      lib.optionals cfg.cli.enable [ pkgs.bitwarden-cli ]
+      ++ lib.optionals cfg.desktop.enable [ pkgs.bitwarden-desktop ];
+  };
+}

--- a/modules/home/default.nix
+++ b/modules/home/default.nix
@@ -8,6 +8,7 @@
     ./alacritty.nix
     ./android.nix
     ./bat.nix
+    ./bitwarden.nix
     ./browser.nix
     ./byobu.nix
     ./common.nix


### PR DESCRIPTION
## What changed

- add independent Home Manager options for the Bitwarden CLI and desktop client
- install both clients by default in the Dubnium workstation profile
- list both toggles with explicit enablement examples in the canonical `user.example.nix` option catalog
- document Vaultwarden endpoint configuration and safe `BW_SESSION` handling
- preserve the existing managed Firefox Bitwarden extension policy

## Validation targets

- `bw --version`
- Bitwarden desktop launches under Hyprland/Wayland
- headless profiles do not receive the desktop package
- no credentials, server tokens, exports, or session values enter tracked configuration

Closes #23