### PR TITLE
feat(android): install Android agent CLI

### DIFF
--- a/modules/home/android.nix
+++ b/modules/home/android.nix
@@ -11,7 +11,28 @@
     home.packages = with pkgs; [
       android-studio
       android-tools
+      curl
     ];
+
+    home.activation.installAndroidAgentCli = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      target="$HOME/.local/bin/android"
+
+      if [ ! -x "$target" ]; then
+        mkdir -p "$(dirname "$target")"
+        tmp="$(${pkgs.coreutils}/bin/mktemp)"
+        trap '${pkgs.coreutils}/bin/rm -f "$tmp"' EXIT
+
+        ${pkgs.curl}/bin/curl \
+          --fail \
+          --silent \
+          --show-error \
+          --location \
+          https://dl.google.com/android/cli/latest/linux_x86_64/android \
+          --output "$tmp"
+
+        ${pkgs.coreutils}/bin/install -m 0755 "$tmp" "$target"
+      fi
+    '';
 
     xdg.configFile."zsh/config.d/android".source = ../../files/home/.config/zsh/config.d/android;
 

--- a/modules/home/android.nix
+++ b/modules/home/android.nix
@@ -11,7 +11,6 @@
     home.packages = with pkgs; [
       android-studio
       android-tools
-      curl
     ];
 
     home.activation.installAndroidAgentCli = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
@@ -22,15 +21,19 @@
         tmp="$(${pkgs.coreutils}/bin/mktemp)"
         trap '${pkgs.coreutils}/bin/rm -f "$tmp"' EXIT
 
-        ${pkgs.curl}/bin/curl \
+        if ${pkgs.curl}/bin/curl \
           --fail \
           --silent \
           --show-error \
           --location \
+          --connect-timeout 15 \
+          --max-time 120 \
           https://dl.google.com/android/cli/latest/linux_x86_64/android \
-          --output "$tmp"
-
-        ${pkgs.coreutils}/bin/install -m 0755 "$tmp" "$target"
+          --output "$tmp"; then
+          ${pkgs.coreutils}/bin/install -m 0755 "$tmp" "$target"
+        else
+          echo "warning: Android CLI download unavailable; install it from https://developer.android.com/tools/agents" >&2
+        fi
       fi
     '';
 


### PR DESCRIPTION
## Summary

- install Google's Android CLI when the Android Home Manager profile is enabled
- place the self-updating `android` binary in `~/.local/bin`
- use the official Linux x86_64 download endpoint
- keep Home Manager activation successful when Google's gated download is unavailable

## Notes

The upstream download is a mutable `latest` artifact and the CLI updates itself with `android update`, so this intentionally uses a guarded, best-effort Home Manager activation rather than pretending it is a reproducible fixed-output Nix package.

After first successful installation, run `android init` to install the official `android-cli` agent skill.