### PR TITLE
Enable Bluetooth audio support

### DIFF
--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -16,9 +16,6 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v17
 
-      - name: Configure Cache
-        uses: DeterminateSystems/flakehub-cache-action@v1
-
       - name: Flake Check
         run: nix flake check --no-build
 

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -16,6 +16,17 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@v17
 
+      - name: Configure Cache
+        uses: DeterminateSystems/flakehub-cache-action@v1
+
+      - name: Diagnose Flake Inputs
+        run: |
+          nix --version
+          nix flake metadata --json | jq .
+          nix flake archive --json | jq .
+          nix path-info /nix/store/6b2ym9rs3dsniij8gs20d3qp2bwqj9z6-source || true
+          nix eval --show-trace .#nixosConfigurations.nixos.config.system.build.toplevel.drvPath
+
       - name: Flake Check
         run: nix flake check --no-build
 

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -19,14 +19,6 @@ jobs:
       - name: Configure Cache
         uses: DeterminateSystems/flakehub-cache-action@v1
 
-      - name: Diagnose Flake Inputs
-        run: |
-          nix --version
-          nix flake metadata --json | jq .
-          nix flake archive --json | jq .
-          nix path-info /nix/store/6b2ym9rs3dsniij8gs20d3qp2bwqj9z6-source || true
-          nix eval --show-trace .#nixosConfigurations.nixos.config.system.build.toplevel.drvPath
-
       - name: Flake Check
         run: nix flake check --no-build
 

--- a/hosts/nixos/configuration.nix
+++ b/hosts/nixos/configuration.nix
@@ -13,6 +13,11 @@
   time.timeZone = "America/Vancouver";
   i18n.defaultLocale = "en_US.UTF-8";
 
+  dubnium = {
+    audio.enable = true;
+    bluetooth.enable = true;
+  };
+
   # This host is evaluated by CI as a generic NixOS verification target.
   # It is not an installer image and should not try to install GRUB to a
   # real disk during evaluation.

--- a/modules/nixos/audio.nix
+++ b/modules/nixos/audio.nix
@@ -1,0 +1,22 @@
+{
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.dubnium.audio;
+in
+{
+  options.dubnium.audio.enable = lib.mkEnableOption "PipeWire desktop audio support";
+
+  config = lib.mkIf cfg.enable {
+    security.rtkit.enable = true;
+
+    services.pipewire = {
+      enable = true;
+      alsa.enable = true;
+      alsa.support32Bit = true;
+      pulse.enable = true;
+    };
+  };
+}

--- a/modules/nixos/bluetooth.nix
+++ b/modules/nixos/bluetooth.nix
@@ -1,0 +1,19 @@
+{
+  ...
+}:
+{
+  hardware.bluetooth = {
+    enable = true;
+    powerOnBoot = true;
+  };
+
+  services.blueman.enable = true;
+
+  security.rtkit.enable = true;
+  services.pipewire = {
+    enable = true;
+    alsa.enable = true;
+    alsa.support32Bit = true;
+    pulse.enable = true;
+  };
+}

--- a/modules/nixos/bluetooth.nix
+++ b/modules/nixos/bluetooth.nix
@@ -1,19 +1,20 @@
 {
+  config,
+  lib,
   ...
 }:
+let
+  cfg = config.dubnium.bluetooth;
+in
 {
-  hardware.bluetooth = {
-    enable = true;
-    powerOnBoot = true;
-  };
+  options.dubnium.bluetooth.enable = lib.mkEnableOption "Bluetooth device support";
 
-  services.blueman.enable = true;
+  config = lib.mkIf cfg.enable {
+    hardware.bluetooth = {
+      enable = true;
+      powerOnBoot = true;
+    };
 
-  security.rtkit.enable = true;
-  services.pipewire = {
-    enable = true;
-    alsa.enable = true;
-    alsa.support32Bit = true;
-    pulse.enable = true;
+    services.blueman.enable = true;
   };
 }

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -3,6 +3,7 @@
 }:
 {
   imports = [
+    ./audio.nix
     ./bluetooth.nix
     ./fonts.nix
     ./motd.nix

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -3,6 +3,7 @@
 }:
 {
   imports = [
+    ./bluetooth.nix
     ./fonts.nix
     ./motd.nix
     ./podman.nix


### PR DESCRIPTION
## What changed

- add an option-gated Bluetooth module that enables BlueZ and Blueman only when requested by a host
- add a separate option-gated PipeWire audio module with ALSA, PulseAudio compatibility, and RTKit
- enable both options explicitly for the graphical `hosts/nixos` configuration
- keep the shared NixOS module set safe for future headless consumers

## Why

This provides the system support needed to pair and use AirPods and other Bluetooth headsets without unconditionally enabling desktop Bluetooth and audio services on every host.

## Validation

- reviewed the complete branch diff against `main`
- Bluetooth and audio ownership are separated
- both modules default to disabled and are enabled explicitly by the graphical host
- Nix CI is expected to rerun for head commit `f8f8b5f36495fc5253e1a43e70a54b1491008a83`

Runtime pairing still requires putting the AirPods into pairing mode and selecting them through Blueman or `bluetoothctl`.