### PR TITLE
fix(waybar): expose audio devices in tooltip

### DIFF
--- a/files/home/.config/waybar/config.jsonc
+++ b/files/home/.config/waybar/config.jsonc
@@ -134,7 +134,8 @@
             "headphone": "",
             "default": ["", "", ""]
         },
-        "on-click": "pavucontrol"
+        "tooltip-format": "Output: {desc}\nInput: {source_desc}",
+        "on-click-middle": "pavucontrol"
     },
     "network": {
         "format-wifi": "{essid} ({signalStrength}%) ",


### PR DESCRIPTION
## Summary
- open `pavucontrol` from the Waybar audio widget on middle-click
- show the active output and input device names in the hover tooltip
- leave the existing output/input volume display unchanged

## Scope
Updates the primary Dubnium Waybar configuration.