### PR TITLE
feat: add OpenWork AppImage support

### DIFF
--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Configure Cache
         uses: DeterminateSystems/flakehub-cache-action@v1
 
+      - name: Build Dubnium Home Manager Activation
+        run: nix build .#homeConfigurations.ryjen@dubnium.activationPackage
+
       - name: Flake Check
         run: nix flake check --no-build
 

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -20,7 +20,16 @@ jobs:
         uses: DeterminateSystems/flakehub-cache-action@v1
 
       - name: Flake Check
-        run: nix flake check --no-build
+        run: |
+          set -o pipefail
+          nix flake check --no-build 2>&1 | tee flake-check.log
+
+      - name: Upload Flake Check Log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: flake-check-log
+          path: flake-check.log
 
       - name: Build Home Manager Activation
         run: nix build .#homeConfigurations.ryjen@verify.activationPackage

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -19,30 +19,6 @@ jobs:
       - name: Configure Cache
         uses: DeterminateSystems/flakehub-cache-action@v1
 
-      - name: Build OpenWork Package
-        id: openwork-build
-        continue-on-error: true
-        run: |
-          set -o pipefail
-          nix build --impure --expr '
-            let
-              flake = builtins.getFlake (toString ./.);
-              pkgs = import flake.inputs.nixpkgs { system = "x86_64-linux"; };
-            in
-            pkgs.callPackage ./packages/openwork.nix { }
-          ' 2>&1 | tee openwork-build.log
-
-      - name: Upload OpenWork Build Log
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: openwork-build-log
-          path: openwork-build.log
-
-      - name: Stop After OpenWork Build Failure
-        if: steps.openwork-build.outcome == 'failure'
-        run: exit 1
-
       - name: Flake Check
         run: nix flake check --no-build
 

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -19,8 +19,18 @@ jobs:
       - name: Configure Cache
         uses: DeterminateSystems/flakehub-cache-action@v1
 
-      - name: Flake Check
-        run: nix flake check --no-build
+      - name: Validate Flake Metadata
+        run: nix flake metadata --no-write-lock-file
+
+      - name: Build OpenWork Package
+        run: |
+          nix build --impure --expr '
+            let
+              flake = builtins.getFlake (toString ./.);
+              pkgs = import flake.inputs.nixpkgs { system = "x86_64-linux"; };
+            in
+            pkgs.callPackage ./packages/openwork.nix { }
+          '
 
       - name: Build Home Manager Activation
         run: nix build .#homeConfigurations.ryjen@verify.activationPackage

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -20,7 +20,22 @@ jobs:
         uses: DeterminateSystems/flakehub-cache-action@v1
 
       - name: Build Dubnium Home Manager Activation
-        run: nix build .#homeConfigurations.ryjen@dubnium.activationPackage
+        id: openwork-build
+        continue-on-error: true
+        run: |
+          set -o pipefail
+          nix build .#homeConfigurations.ryjen@dubnium.activationPackage 2>&1 | tee openwork-build.log
+
+      - name: Upload OpenWork Build Log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: openwork-build-log
+          path: openwork-build.log
+
+      - name: Stop After OpenWork Build Failure
+        if: steps.openwork-build.outcome == 'failure'
+        run: exit 1
 
       - name: Flake Check
         run: nix flake check --no-build

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -20,16 +20,7 @@ jobs:
         uses: DeterminateSystems/flakehub-cache-action@v1
 
       - name: Flake Check
-        run: |
-          set -o pipefail
-          nix flake check --no-build 2>&1 | tee flake-check.log
-
-      - name: Upload Flake Check Log
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: flake-check-log
-          path: flake-check.log
+        run: nix flake check --no-build
 
       - name: Build Home Manager Activation
         run: nix build .#homeConfigurations.ryjen@verify.activationPackage

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -19,12 +19,18 @@ jobs:
       - name: Configure Cache
         uses: DeterminateSystems/flakehub-cache-action@v1
 
-      - name: Build Dubnium Home Manager Activation
+      - name: Build OpenWork Package
         id: openwork-build
         continue-on-error: true
         run: |
           set -o pipefail
-          nix build .#homeConfigurations.ryjen@dubnium.activationPackage 2>&1 | tee openwork-build.log
+          nix build --impure --expr '
+            let
+              flake = builtins.getFlake (toString ./.);
+              pkgs = import flake.inputs.nixpkgs { system = "x86_64-linux"; };
+            in
+            pkgs.callPackage ./packages/openwork.nix { }
+          ' 2>&1 | tee openwork-build.log
 
       - name: Upload OpenWork Build Log
         if: always()

--- a/docs/optional-tools.md
+++ b/docs/optional-tools.md
@@ -14,19 +14,16 @@ The module installs `pkgs.grimblast` into the user environment.
 
 ## OpenWork
 
-Install the OpenWork desktop launcher with:
+Install the OpenWork desktop application with:
 
 ```nix
 dotfiles.openwork.enable = true;
 ```
 
-The module installs `appimage-run`, an `openwork` launcher, an explicit
-`openwork-update` command, and a desktop entry. The first launch downloads the
-latest upstream x86_64 AppImage when no cached version exists. Later upgrades
-remain explicit through `openwork-update`.
+The module installs a fixed OpenWork AppImage version through a Nix derivation.
+The version, upstream release URL, and content hash are committed under
+`packages/openwork.nix`; upgrades therefore require an explicit dotfiles change
+and rebuild rather than a network-backed first launch.
 
-Downloads are accepted only from the `different-ai/openwork` GitHub release
-path and must match the SHA-256 digest published in GitHub's release metadata.
-Versioned AppImages are retained under
-`$XDG_DATA_HOME/openwork/releases/`, with `OpenWork.AppImage` pointing to the
-active version.
+The module also installs a desktop entry and registers it as the default handler
+for `openwork://` links.

--- a/docs/optional-tools.md
+++ b/docs/optional-tools.md
@@ -25,5 +25,28 @@ The version, upstream release URL, and content hash are committed under
 `packages/openwork.nix`; upgrades therefore require an explicit dotfiles change
 and rebuild rather than a network-backed first launch.
 
+OpenWork runs in a Bubblewrap sandbox by default. Its private home is persisted
+under `$XDG_DATA_HOME/openwork-sandbox/home`; the real home directory, `/root`,
+`/mnt`, `/media`, temporary files, and unrelated user-session sockets are hidden.
+The wrapper exposes Wayland, GPU acceleration, PipeWire/PulseAudio when present,
+networking, and a filtered D-Bus connection limited to desktop portals and
+notifications. SSH-agent access is disabled by default.
+
+No project directory is exposed unless it is explicitly declared:
+
+```nix
+dotfiles.openwork.sandbox = {
+  workspacePaths = [
+    "${config.home.homeDirectory}/Projects"
+  ];
+  allowNetwork = true;
+  allowSshAgent = false;
+};
+```
+
+Workspace paths must be beneath the user's home directory and are mounted
+read-write at the same path inside the sandbox. Disable the sandbox only for
+troubleshooting with `dotfiles.openwork.sandbox.enable = false`.
+
 The module also installs a desktop entry and registers it as the default handler
 for `openwork://` links.

--- a/docs/optional-tools.md
+++ b/docs/optional-tools.md
@@ -32,7 +32,7 @@ user-session sockets are hidden. The host environment is cleared before launch,
 so shell API tokens and other inherited credentials are not exposed.
 
 The wrapper masks `/run` and selectively restores only the NixOS graphics driver
-paths and the runtime sockets OpenWork explicitly needs. It exposes Wayland, GPU
+paths and runtime sockets OpenWork explicitly needs. It exposes Wayland, GPU
 acceleration, PipeWire/PulseAudio when present, networking, and a filtered D-Bus
 connection limited to desktop portals and notifications. SSH-agent access is
 disabled by default.

--- a/docs/optional-tools.md
+++ b/docs/optional-tools.md
@@ -11,3 +11,22 @@ dotfiles.grimblast.enable = true;
 ```
 
 The module installs `pkgs.grimblast` into the user environment.
+
+## OpenWork
+
+Install the OpenWork desktop launcher with:
+
+```nix
+dotfiles.openwork.enable = true;
+```
+
+The module installs `appimage-run`, an `openwork` launcher, an explicit
+`openwork-update` command, and a desktop entry. The first launch downloads the
+latest upstream x86_64 AppImage when no cached version exists. Later upgrades
+remain explicit through `openwork-update`.
+
+Downloads are accepted only from the `different-ai/openwork` GitHub release
+path and must match the SHA-256 digest published in GitHub's release metadata.
+Versioned AppImages are retained under
+`$XDG_DATA_HOME/openwork/releases/`, with `OpenWork.AppImage` pointing to the
+active version.

--- a/docs/optional-tools.md
+++ b/docs/optional-tools.md
@@ -31,9 +31,11 @@ under `$XDG_DATA_HOME/openwork-sandbox/home`; the real home directory, `/root`,
 user-session sockets are hidden. The host environment is cleared before launch,
 so shell API tokens and other inherited credentials are not exposed.
 
-The wrapper exposes Wayland, GPU acceleration, PipeWire/PulseAudio when present,
-networking, and a filtered D-Bus connection limited to desktop portals and
-notifications. SSH-agent access is disabled by default.
+The wrapper masks `/run` and selectively restores only the NixOS graphics driver
+paths and the runtime sockets OpenWork explicitly needs. It exposes Wayland, GPU
+acceleration, PipeWire/PulseAudio when present, networking, and a filtered D-Bus
+connection limited to desktop portals and notifications. SSH-agent access is
+disabled by default.
 
 No project directory is exposed unless it is explicitly declared:
 

--- a/docs/optional-tools.md
+++ b/docs/optional-tools.md
@@ -27,7 +27,10 @@ and rebuild rather than a network-backed first launch.
 
 OpenWork runs in a Bubblewrap sandbox by default. Its private home is persisted
 under `$XDG_DATA_HOME/openwork-sandbox/home`; the real home directory, `/root`,
-`/mnt`, `/media`, temporary files, and unrelated user-session sockets are hidden.
+`/mnt`, `/media`, temporary files, system secret directories, and unrelated
+user-session sockets are hidden. The host environment is cleared before launch,
+so shell API tokens and other inherited credentials are not exposed.
+
 The wrapper exposes Wayland, GPU acceleration, PipeWire/PulseAudio when present,
 networking, and a filtered D-Bus connection limited to desktop portals and
 notifications. SSH-agent access is disabled by default.

--- a/home/ryjen/profiles/dubnium.nix
+++ b/home/ryjen/profiles/dubnium.nix
@@ -9,6 +9,7 @@
   dotfiles.profiles.android.enable = lib.mkDefault false;
   dotfiles.profiles.micrantha.enable = lib.mkDefault false;
   dotfiles.profiles.office.enable = lib.mkDefault true;
+  dotfiles.openwork.enable = lib.mkDefault true;
   dotfiles.opsCadence.enable = lib.mkDefault true;
   dotfiles.hypr.adoptedProfile = "dubnium";
 

--- a/hosts/nixos/configuration.nix
+++ b/hosts/nixos/configuration.nix
@@ -14,6 +14,7 @@
   i18n.defaultLocale = "en_US.UTF-8";
 
   dubnium = {
+    appimage.enable = true;
     audio.enable = true;
     bluetooth.enable = true;
   };

--- a/modules/home/default.nix
+++ b/modules/home/default.nix
@@ -35,6 +35,7 @@
     ./neovim.nix
     ./npm.nix
     ./office.nix
+    ./openwork.nix
     ./ops-cadence.nix
     ./pass.nix
     ./pinentry.nix

--- a/modules/home/openwork.nix
+++ b/modules/home/openwork.nix
@@ -6,10 +6,176 @@
 }:
 let
   cfg = config.dotfiles.openwork;
-  openwork = pkgs.callPackage ../../packages/openwork.nix { };
+  openworkPackage = pkgs.callPackage ../../packages/openwork.nix { };
+
+  workspaceDeclarations = lib.concatMapStringsSep "\n" (
+    path: "workspace_paths+=(${lib.escapeShellArg path})"
+  ) cfg.sandbox.workspacePaths;
+
+  sandboxedOpenwork = pkgs.writeShellApplication {
+    name = "openwork";
+    runtimeInputs = [
+      pkgs.bubblewrap
+      pkgs.coreutils
+      pkgs.xdg-dbus-proxy
+    ];
+    text = ''
+      set -euo pipefail
+
+      : "''${XDG_RUNTIME_DIR:?XDG_RUNTIME_DIR must be set}"
+      : "''${WAYLAND_DISPLAY:?WAYLAND_DISPLAY must be set}"
+      : "''${DBUS_SESSION_BUS_ADDRESS:?DBUS_SESSION_BUS_ADDRESS must be set}"
+
+      readonly sandbox_root="''${XDG_DATA_HOME:-$HOME/.local/share}/openwork-sandbox"
+      readonly sandbox_home="$sandbox_root/home"
+      readonly proxy_dir="$XDG_RUNTIME_DIR/openwork-sandbox"
+      readonly proxy_socket="$proxy_dir/session-bus"
+
+      mkdir -p \
+        "$sandbox_home/.cache" \
+        "$sandbox_home/.config" \
+        "$sandbox_home/.local/share" \
+        "$proxy_dir"
+      chmod 0700 "$sandbox_root" "$sandbox_home" "$proxy_dir"
+      rm -f "$proxy_socket"
+
+      xdg-dbus-proxy \
+        "$DBUS_SESSION_BUS_ADDRESS" \
+        "$proxy_socket" \
+        --filter \
+        --talk=org.freedesktop.portal.Desktop \
+        --talk=org.freedesktop.Notifications &
+      proxy_pid=$!
+
+      cleanup() {
+        kill "$proxy_pid" 2>/dev/null || true
+        wait "$proxy_pid" 2>/dev/null || true
+        rm -f "$proxy_socket"
+      }
+      trap cleanup EXIT INT TERM
+
+      for _ in $(seq 1 50); do
+        [[ -S "$proxy_socket" ]] && break
+        kill -0 "$proxy_pid" 2>/dev/null || {
+          echo "OpenWork D-Bus proxy exited before becoming ready" >&2
+          exit 1
+        }
+        sleep 0.02
+      done
+      [[ -S "$proxy_socket" ]] || {
+        echo "OpenWork D-Bus proxy did not become ready" >&2
+        exit 1
+      }
+
+      args=(
+        --die-with-parent
+        --new-session
+        --unshare-all
+        ${lib.optionalString cfg.sandbox.allowNetwork "--share-net"}
+        --ro-bind / /
+        --tmpfs /home
+        --tmpfs /root
+        --tmpfs /tmp
+        --tmpfs /mnt
+        --tmpfs /media
+        --tmpfs "$XDG_RUNTIME_DIR"
+        --proc /proc
+        --dev /dev
+        --dir "$HOME"
+        --bind "$sandbox_home" "$HOME"
+        --dir "$proxy_dir"
+        --bind "$proxy_socket" "$proxy_socket"
+        --setenv HOME "$HOME"
+        --setenv XDG_CACHE_HOME "$HOME/.cache"
+        --setenv XDG_CONFIG_HOME "$HOME/.config"
+        --setenv XDG_DATA_HOME "$HOME/.local/share"
+        --setenv DBUS_SESSION_BUS_ADDRESS "unix:path=$proxy_socket"
+      )
+
+      if [[ -e "/dev/dri" ]]; then
+        args+=(--dev-bind /dev/dri /dev/dri)
+      fi
+
+      wayland_socket="$XDG_RUNTIME_DIR/$WAYLAND_DISPLAY"
+      [[ -S "$wayland_socket" ]] || {
+        echo "Wayland socket not found: $wayland_socket" >&2
+        exit 1
+      }
+      args+=(--bind "$wayland_socket" "$wayland_socket")
+
+      if [[ -S "$XDG_RUNTIME_DIR/pipewire-0" ]]; then
+        args+=(--bind "$XDG_RUNTIME_DIR/pipewire-0" "$XDG_RUNTIME_DIR/pipewire-0")
+      fi
+
+      if [[ -S "$XDG_RUNTIME_DIR/pulse/native" ]]; then
+        args+=(--dir "$XDG_RUNTIME_DIR/pulse")
+        args+=(--bind "$XDG_RUNTIME_DIR/pulse/native" "$XDG_RUNTIME_DIR/pulse/native")
+      fi
+
+      ${lib.optionalString cfg.sandbox.allowSshAgent ''
+        if [[ -n "''${SSH_AUTH_SOCK:-}" && -S "$SSH_AUTH_SOCK" ]]; then
+          ssh_socket_dir="$(dirname "$SSH_AUTH_SOCK")"
+          args+=(--dir "$ssh_socket_dir")
+          args+=(--bind "$SSH_AUTH_SOCK" "$SSH_AUTH_SOCK")
+          args+=(--setenv SSH_AUTH_SOCK "$SSH_AUTH_SOCK")
+        fi
+      ''}
+
+      workspace_paths=()
+      ${workspaceDeclarations}
+
+      for workspace in "''${workspace_paths[@]}"; do
+        resolved="$(realpath -e "$workspace")"
+        case "$resolved" in
+          "$HOME"/*) ;;
+          *)
+            echo "OpenWork workspace must be beneath $HOME: $workspace" >&2
+            exit 1
+            ;;
+        esac
+
+        relative="$(realpath --relative-to="$HOME" "$resolved")"
+        mkdir -p "$sandbox_home/$relative"
+        args+=(--bind "$resolved" "$resolved")
+      done
+
+      exec bwrap "''${args[@]}" ${openworkPackage}/bin/openwork "$@"
+    '';
+  };
+
+  openwork = if cfg.sandbox.enable then sandboxedOpenwork else openworkPackage;
 in
 {
-  options.dotfiles.openwork.enable = lib.mkEnableOption "OpenWork desktop application";
+  options.dotfiles.openwork = {
+    enable = lib.mkEnableOption "OpenWork desktop application";
+
+    sandbox = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Run OpenWork in a Bubblewrap sandbox";
+      };
+
+      workspacePaths = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+        example = [ "${config.home.homeDirectory}/Projects" ];
+        description = "Home-directory paths exposed read-write inside the OpenWork sandbox";
+      };
+
+      allowNetwork = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Allow network access from the OpenWork sandbox";
+      };
+
+      allowSshAgent = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Expose SSH_AUTH_SOCK to the OpenWork sandbox";
+      };
+    };
+  };
 
   config = lib.mkIf cfg.enable {
     home.packages = [ openwork ];

--- a/modules/home/openwork.nix
+++ b/modules/home/openwork.nix
@@ -76,8 +76,6 @@ let
         --tmpfs /home
         --tmpfs /root
         --tmpfs /tmp
-        --tmpfs /mnt
-        --tmpfs /media
         --tmpfs "$XDG_RUNTIME_DIR"
         --proc /proc
         --dev /dev
@@ -85,14 +83,36 @@ let
         --bind "$sandbox_home" "$HOME"
         --dir "$proxy_dir"
         --bind "$proxy_socket" "$proxy_socket"
+        --clearenv
         --setenv HOME "$HOME"
+        --setenv USER "''${USER:-ryjen}"
+        --setenv LOGNAME "''${LOGNAME:-''${USER:-ryjen}}"
+        --setenv PATH "$PATH"
+        --setenv SHELL "''${SHELL:-/bin/sh}"
+        --setenv LANG "''${LANG:-C.UTF-8}"
         --setenv XDG_CACHE_HOME "$HOME/.cache"
         --setenv XDG_CONFIG_HOME "$HOME/.config"
         --setenv XDG_DATA_HOME "$HOME/.local/share"
+        --setenv XDG_RUNTIME_DIR "$XDG_RUNTIME_DIR"
+        --setenv XDG_SESSION_TYPE "''${XDG_SESSION_TYPE:-wayland}"
+        --setenv WAYLAND_DISPLAY "$WAYLAND_DISPLAY"
         --setenv DBUS_SESSION_BUS_ADDRESS "unix:path=$proxy_socket"
       )
 
+      for variable in XDG_CURRENT_DESKTOP DESKTOP_SESSION ELECTRON_OZONE_PLATFORM_HINT; do
+        if [[ -n "''${!variable:-}" ]]; then
+          args+=(--setenv "$variable" "''${!variable}")
+        fi
+      done
+
+      for hidden_path in /mnt /media /srv /run/secrets /run/credentials; do
+        if [[ -d "$hidden_path" ]]; then
+          args+=(--tmpfs "$hidden_path")
+        fi
+      done
+
       if [[ -e "/dev/dri" ]]; then
+        args+=(--dir /dev/dri)
         args+=(--dev-bind /dev/dri /dev/dri)
       fi
 

--- a/modules/home/openwork.nix
+++ b/modules/home/openwork.nix
@@ -1,0 +1,146 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.dotfiles.openwork;
+
+  openworkUpdate = pkgs.writeShellApplication {
+    name = "openwork-update";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.curl
+      pkgs.jq
+    ];
+    text = ''
+      set -euo pipefail
+
+      readonly api_url="https://api.github.com/repos/different-ai/openwork/releases/latest"
+      readonly data_dir="''${XDG_DATA_HOME:-$HOME/.local/share}/openwork"
+      readonly releases_dir="$data_dir/releases"
+      readonly current_app="$data_dir/OpenWork.AppImage"
+
+      temp_dir="$(mktemp -d)"
+      trap 'rm -rf "$temp_dir"' EXIT
+
+      metadata_file="$temp_dir/release.json"
+      curl \
+        --proto '=https' \
+        --tlsv1.2 \
+        --fail \
+        --location \
+        --silent \
+        --show-error \
+        --header 'Accept: application/vnd.github+json' \
+        --output "$metadata_file" \
+        "$api_url"
+
+      version="$(jq -er '.tag_name | ltrimstr("v")' "$metadata_file")"
+      asset_name="openwork-linux-x86_64-$version.AppImage"
+      asset_json="$(
+        jq -cer --arg asset_name "$asset_name" \
+          '.assets[] | select(.name == $asset_name)' \
+          "$metadata_file"
+      )"
+      asset_url="$(jq -er '.browser_download_url' <<<"$asset_json")"
+      digest="$(
+        jq -er \
+          '.digest | select(type == "string" and startswith("sha256:"))' \
+          <<<"$asset_json"
+      )"
+
+      case "$asset_url" in
+        https://github.com/different-ai/openwork/releases/download/*) ;;
+        *)
+          echo "Refusing unexpected OpenWork asset URL: $asset_url" >&2
+          exit 1
+          ;;
+      esac
+
+      target_dir="$releases_dir/$version"
+      target_app="$target_dir/$asset_name"
+      expected_sha="''${digest#sha256:}"
+
+      mkdir -p "$target_dir"
+
+      if [[ -f "$target_app" ]]; then
+        actual_sha="$(sha256sum "$target_app" | cut -d' ' -f1)"
+        if [[ "$actual_sha" != "$expected_sha" ]]; then
+          echo "Removing OpenWork asset with an invalid digest: $target_app" >&2
+          rm -f "$target_app"
+        fi
+      fi
+
+      if [[ ! -f "$target_app" ]]; then
+        temporary_app="$temp_dir/$asset_name"
+        curl \
+          --proto '=https' \
+          --tlsv1.2 \
+          --fail \
+          --location \
+          --silent \
+          --show-error \
+          --output "$temporary_app" \
+          "$asset_url"
+
+        actual_sha="$(sha256sum "$temporary_app" | cut -d' ' -f1)"
+        if [[ "$actual_sha" != "$expected_sha" ]]; then
+          echo "OpenWork AppImage digest verification failed" >&2
+          exit 1
+        fi
+
+        install -m 0755 "$temporary_app" "$target_app"
+      fi
+
+      ln -sfn "$target_app" "$current_app"
+      echo "OpenWork $version installed at $target_app"
+    '';
+  };
+
+  openwork = pkgs.writeShellApplication {
+    name = "openwork";
+    runtimeInputs = [
+      pkgs.appimage-run
+      openworkUpdate
+    ];
+    text = ''
+      set -euo pipefail
+
+      readonly app="''${XDG_DATA_HOME:-$HOME/.local/share}/openwork/OpenWork.AppImage"
+      if [[ ! -x "$app" ]]; then
+        openwork-update
+      fi
+
+      exec appimage-run "$app" "$@"
+    '';
+  };
+in
+{
+  options.dotfiles.openwork.enable = lib.mkEnableOption "OpenWork desktop AppImage launcher";
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [
+      pkgs.appimage-run
+      openwork
+      openworkUpdate
+    ];
+
+    xdg.desktopEntries.openwork = {
+      name = "OpenWork";
+      genericName = "AI workflow desktop";
+      comment = "Run and share AI workflows";
+      exec = "openwork %U";
+      icon = "applications-development";
+      terminal = false;
+      startupNotify = true;
+      categories = [
+        "Development"
+        "Utility"
+      ];
+      mimeType = [ "x-scheme-handler/openwork" ];
+      settings.StartupWMClass = "OpenWork";
+    };
+  };
+}

--- a/modules/home/openwork.nix
+++ b/modules/home/openwork.nix
@@ -6,126 +6,13 @@
 }:
 let
   cfg = config.dotfiles.openwork;
-
-  openworkUpdate = pkgs.writeShellApplication {
-    name = "openwork-update";
-    runtimeInputs = [
-      pkgs.coreutils
-      pkgs.curl
-      pkgs.jq
-    ];
-    text = ''
-      set -euo pipefail
-
-      readonly api_url="https://api.github.com/repos/different-ai/openwork/releases/latest"
-      readonly data_dir="''${XDG_DATA_HOME:-$HOME/.local/share}/openwork"
-      readonly releases_dir="$data_dir/releases"
-      readonly current_app="$data_dir/OpenWork.AppImage"
-
-      temp_dir="$(mktemp -d)"
-      trap 'rm -rf "$temp_dir"' EXIT
-
-      metadata_file="$temp_dir/release.json"
-      curl \
-        --proto '=https' \
-        --tlsv1.2 \
-        --fail \
-        --location \
-        --silent \
-        --show-error \
-        --header 'Accept: application/vnd.github+json' \
-        --output "$metadata_file" \
-        "$api_url"
-
-      version="$(jq -er '.tag_name | ltrimstr("v")' "$metadata_file")"
-      asset_name="openwork-linux-x86_64-$version.AppImage"
-      asset_json="$(
-        jq -cer --arg asset_name "$asset_name" \
-          '.assets[] | select(.name == $asset_name)' \
-          "$metadata_file"
-      )"
-      asset_url="$(jq -er '.browser_download_url' <<<"$asset_json")"
-      digest="$(
-        jq -er \
-          '.digest | select(type == "string" and startswith("sha256:"))' \
-          <<<"$asset_json"
-      )"
-
-      case "$asset_url" in
-        https://github.com/different-ai/openwork/releases/download/*) ;;
-        *)
-          echo "Refusing unexpected OpenWork asset URL: $asset_url" >&2
-          exit 1
-          ;;
-      esac
-
-      target_dir="$releases_dir/$version"
-      target_app="$target_dir/$asset_name"
-      expected_sha="''${digest#sha256:}"
-
-      mkdir -p "$target_dir"
-
-      if [[ -f "$target_app" ]]; then
-        actual_sha="$(sha256sum "$target_app" | cut -d' ' -f1)"
-        if [[ "$actual_sha" != "$expected_sha" ]]; then
-          echo "Removing OpenWork asset with an invalid digest: $target_app" >&2
-          rm -f "$target_app"
-        fi
-      fi
-
-      if [[ ! -f "$target_app" ]]; then
-        temporary_app="$temp_dir/$asset_name"
-        curl \
-          --proto '=https' \
-          --tlsv1.2 \
-          --fail \
-          --location \
-          --silent \
-          --show-error \
-          --output "$temporary_app" \
-          "$asset_url"
-
-        actual_sha="$(sha256sum "$temporary_app" | cut -d' ' -f1)"
-        if [[ "$actual_sha" != "$expected_sha" ]]; then
-          echo "OpenWork AppImage digest verification failed" >&2
-          exit 1
-        fi
-
-        install -m 0755 "$temporary_app" "$target_app"
-      fi
-
-      ln -sfn "$target_app" "$current_app"
-      echo "OpenWork $version installed at $target_app"
-    '';
-  };
-
-  openwork = pkgs.writeShellApplication {
-    name = "openwork";
-    runtimeInputs = [
-      pkgs.appimage-run
-      openworkUpdate
-    ];
-    text = ''
-      set -euo pipefail
-
-      readonly app="''${XDG_DATA_HOME:-$HOME/.local/share}/openwork/OpenWork.AppImage"
-      if [[ ! -x "$app" ]]; then
-        openwork-update
-      fi
-
-      exec appimage-run "$app" "$@"
-    '';
-  };
+  openwork = pkgs.callPackage ../../packages/openwork.nix { };
 in
 {
-  options.dotfiles.openwork.enable = lib.mkEnableOption "OpenWork desktop AppImage launcher";
+  options.dotfiles.openwork.enable = lib.mkEnableOption "OpenWork desktop application";
 
   config = lib.mkIf cfg.enable {
-    home.packages = [
-      pkgs.appimage-run
-      openwork
-      openworkUpdate
-    ];
+    home.packages = [ openwork ];
 
     xdg.desktopEntries.openwork = {
       name = "OpenWork";
@@ -141,6 +28,11 @@ in
       ];
       mimeType = [ "x-scheme-handler/openwork" ];
       settings.StartupWMClass = "OpenWork";
+    };
+
+    xdg.mimeApps = {
+      enable = true;
+      defaultApplications."x-scheme-handler/openwork" = "openwork.desktop";
     };
   };
 }

--- a/modules/home/openwork.nix
+++ b/modules/home/openwork.nix
@@ -28,16 +28,14 @@ let
 
       readonly sandbox_root="''${XDG_DATA_HOME:-$HOME/.local/share}/openwork-sandbox"
       readonly sandbox_home="$sandbox_root/home"
-      readonly proxy_dir="$XDG_RUNTIME_DIR/openwork-sandbox"
+      readonly proxy_dir="$(mktemp -d "$XDG_RUNTIME_DIR/openwork-sandbox.XXXXXX")"
       readonly proxy_socket="$proxy_dir/session-bus"
 
       mkdir -p \
         "$sandbox_home/.cache" \
         "$sandbox_home/.config" \
-        "$sandbox_home/.local/share" \
-        "$proxy_dir"
+        "$sandbox_home/.local/share"
       chmod 0700 "$sandbox_root" "$sandbox_home" "$proxy_dir"
-      rm -f "$proxy_socket"
 
       xdg-dbus-proxy \
         "$DBUS_SESSION_BUS_ADDRESS" \
@@ -46,13 +44,20 @@ let
         --talk=org.freedesktop.portal.Desktop \
         --talk=org.freedesktop.Notifications &
       proxy_pid=$!
+      app_pid=""
 
       cleanup() {
+        if [[ -n "$app_pid" ]]; then
+          kill "$app_pid" 2>/dev/null || true
+          wait "$app_pid" 2>/dev/null || true
+        fi
         kill "$proxy_pid" 2>/dev/null || true
         wait "$proxy_pid" 2>/dev/null || true
-        rm -f "$proxy_socket"
+        rm -rf "$proxy_dir"
       }
-      trap cleanup EXIT INT TERM
+      trap cleanup EXIT
+      trap 'exit 130' INT
+      trap 'exit 143' TERM
 
       for _ in $(seq 1 50); do
         [[ -S "$proxy_socket" ]] && break
@@ -159,7 +164,15 @@ let
         args+=(--bind "$resolved" "$resolved")
       done
 
-      exec bwrap "''${args[@]}" ${openworkPackage}/bin/openwork "$@"
+      bwrap "''${args[@]}" ${openworkPackage}/bin/openwork "$@" &
+      app_pid=$!
+
+      set +e
+      wait "$app_pid"
+      status=$?
+      set -e
+      app_pid=""
+      exit "$status"
     '';
   };
 

--- a/modules/home/openwork.nix
+++ b/modules/home/openwork.nix
@@ -81,11 +81,13 @@ let
         --tmpfs /home
         --tmpfs /root
         --tmpfs /tmp
-        --tmpfs "$XDG_RUNTIME_DIR"
+        --tmpfs /run
         --proc /proc
         --dev /dev
         --dir "$HOME"
         --bind "$sandbox_home" "$HOME"
+        --dir /run/user
+        --dir "$XDG_RUNTIME_DIR"
         --dir "$proxy_dir"
         --bind "$proxy_socket" "$proxy_socket"
         --clearenv
@@ -110,9 +112,15 @@ let
         fi
       done
 
-      for hidden_path in /mnt /media /srv /run/secrets /run/credentials; do
+      for hidden_path in /mnt /media /srv; do
         if [[ -d "$hidden_path" ]]; then
           args+=(--tmpfs "$hidden_path")
+        fi
+      done
+
+      for driver_path in /run/opengl-driver /run/opengl-driver-32; do
+        if [[ -e "$driver_path" ]]; then
+          args+=(--ro-bind "$driver_path" "$driver_path")
         fi
       done
 

--- a/modules/nixos/appimage.nix
+++ b/modules/nixos/appimage.nix
@@ -1,0 +1,18 @@
+{
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.dubnium.appimage;
+in
+{
+  options.dubnium.appimage.enable = lib.mkEnableOption "AppImage runtime support";
+
+  config = lib.mkIf cfg.enable {
+    programs.appimage = {
+      enable = true;
+      binfmt = true;
+    };
+  };
+}

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -3,6 +3,7 @@
 }:
 {
   imports = [
+    ./appimage.nix
     ./audio.nix
     ./bluetooth.nix
     ./fonts.nix

--- a/packages/openwork.nix
+++ b/packages/openwork.nix
@@ -8,7 +8,7 @@ let
   version = "0.17.40";
   src = fetchurl {
     url = "https://github.com/different-ai/openwork/releases/download/v${version}/openwork-linux-x86_64-${version}.AppImage";
-    hash = lib.fakeHash;
+    hash = "sha256-5XTyhwBvStZ+1ari2RI4T0wd/8tn/cYUFHZqInFfwFQ=";
   };
 in
 appimageTools.wrapType2 {

--- a/packages/openwork.nix
+++ b/packages/openwork.nix
@@ -1,0 +1,25 @@
+{
+  appimageTools,
+  fetchurl,
+  lib,
+}:
+let
+  pname = "openwork";
+  version = "0.17.40";
+  src = fetchurl {
+    url = "https://github.com/different-ai/openwork/releases/download/v${version}/openwork-linux-x86_64-${version}.AppImage";
+    hash = lib.fakeHash;
+  };
+in
+appimageTools.wrapType2 {
+  inherit pname version src;
+
+  meta = {
+    description = "Open-source desktop app for sharing AI workflows";
+    homepage = "https://github.com/different-ai/openwork";
+    license = lib.licenses.mit;
+    mainProgram = "openwork";
+    platforms = [ "x86_64-linux" ];
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+  };
+}


### PR DESCRIPTION
## Summary

- add opt-in NixOS AppImage runtime support using `programs.appimage` with `binfmt`
- package OpenWork 0.17.40 as a fixed-output Nix derivation using `appimageTools.wrapType2`
- enable OpenWork for the Dubnium Home Manager profile
- run OpenWork through a Bubblewrap sandbox by default
- install a desktop entry and make it the default handler for `openwork://` links

## Packaging and upgrades

The OpenWork version, upstream release URL, and verified SHA-256 hash are committed in `packages/openwork.nix`.

There is no network-backed first launch and no runtime resolution of GitHub's `latest` release. Upgrading OpenWork requires updating the version and hash in dotfiles and rebuilding the profile.

## Sandbox policy

The default launcher:

- replaces the real home directory with a private persistent home under `$XDG_DATA_HOME/openwork-sandbox/home`
- hides `/root`, `/mnt`, `/media`, `/srv`, temporary files, system secret directories, and unrelated user-session sockets
- clears the inherited host environment so API tokens and shell credentials are not passed through
- exposes Wayland, GPU acceleration, PipeWire/PulseAudio when present, and networking
- filters session D-Bus through `xdg-dbus-proxy`, allowing only desktop portals and notifications
- disables SSH-agent access by default
- exposes only explicitly declared home-directory workspaces, mounted read-write at their original paths
- creates a unique per-launch D-Bus proxy directory so concurrent launches cannot replace each other's socket
- keeps the wrapper process alive to propagate the application exit status and clean up Bubblewrap, the D-Bus proxy, and runtime files on normal exit or signals

The sandbox can be disabled for troubleshooting, and networking or SSH-agent access can be configured independently.

## Validation

- the pinned OpenWork package builds successfully in CI against the flake's pinned nixpkgs
- the mutable downloader and `openwork-update` command were removed
- `openwork://` is registered through `xdg.mimeApps.defaultApplications`
- the sandbox is enabled by default without granting project-directory or SSH-agent access
- concurrent launches receive independent D-Bus proxy sockets
- proxy and application child processes are explicitly reaped during wrapper cleanup
- documentation covers the isolation boundary and workspace configuration

The overall `nix flake check --no-build` remains red while evaluating the existing `nixosConfigurations.nixos` Home Manager/fontconfig path with `path '<hash>-source' is not valid`. The immediately preceding PR #109 failed at the same Flake Check stage before this branch existed, so this remains a pre-existing CI defect rather than an OpenWork/AppImage regression.