### PR TITLE
feat: enforce explicit local user option catalog

### DIFF
--- a/.github/workflows/user-option-catalog.yml
+++ b/.github/workflows/user-option-catalog.yml
@@ -33,4 +33,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Verify catalog and imports
-        run: python3 scripts/verify-user-option-catalog.py "$GITHUB_WORKSPACE"
+        id: verify
+        shell: bash
+        run: |
+          set +e
+          python3 scripts/verify-user-option-catalog.py "$GITHUB_WORKSPACE" > user-option-catalog-report.txt 2>&1
+          status=$?
+          cat user-option-catalog-report.txt
+          exit "$status"
+      - name: Upload bounded failure report
+        if: failure() && steps.verify.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: user-option-catalog-report
+          path: user-option-catalog-report.txt
+          if-no-files-found: error
+          retention-days: 3

--- a/.github/workflows/user-option-catalog.yml
+++ b/.github/workflows/user-option-catalog.yml
@@ -1,0 +1,36 @@
+name: User option catalog
+
+on:
+  pull_request:
+    paths:
+      - "flake.nix"
+      - "home/ryjen/**"
+      - "modules/home/**"
+      - "scripts/verify-user-option-catalog.py"
+      - ".github/workflows/user-option-catalog.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "flake.nix"
+      - "home/ryjen/**"
+      - "modules/home/**"
+      - "scripts/verify-user-option-catalog.py"
+      - ".github/workflows/user-option-catalog.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: user-option-catalog-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  verify:
+    name: Verify user option catalog
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify catalog and imports
+        run: python3 scripts/verify-user-option-catalog.py "$GITHUB_WORKSPACE"

--- a/home/ryjen/meeting-verify-home.nix
+++ b/home/ryjen/meeting-verify-home.nix
@@ -1,12 +1,14 @@
 {
   username,
+  lib,
   ...
 }:
 {
   imports = [
     ./layers/graphical.nix
     ./profiles/dubnium.nix
-  ];
+  ]
+  ++ lib.optional (builtins.pathExists ./user.local.nix) ./user.local.nix;
 
   dotfiles.meeting.presentationOutput = "DP-1";
   dotfiles.meeting.cameraDevice = null;

--- a/home/ryjen/user.example.nix
+++ b/home/ryjen/user.example.nix
@@ -42,6 +42,7 @@
 
   # Hardware/profile variants that are safe to select locally.
   # dotfiles.alacritty.adoptedProfile = "empty";
+  # dotfiles.hypr.adoptedProfile = "empty";
   # dotfiles.waybar.variant = "workstation";
 
   # OpenWork desktop app and sandbox boundary.

--- a/home/ryjen/user.example.nix
+++ b/home/ryjen/user.example.nix
@@ -40,6 +40,17 @@
   # dotfiles.grimblast.enable = false;
   # dotfiles.graphical.keyring.enable = false;
 
+  # Hardware/profile variants that are safe to select locally.
+  # dotfiles.alacritty.adoptedProfile = "empty";
+  # dotfiles.waybar.variant = "workstation";
+
+  # OpenWork desktop app and sandbox boundary.
+  # dotfiles.openwork.enable = false;
+  # dotfiles.openwork.sandbox.enable = true;
+  # dotfiles.openwork.sandbox.workspacePaths = [ "${config.home.homeDirectory}/Projects" ];
+  # dotfiles.openwork.sandbox.allowNetwork = true;
+  # dotfiles.openwork.sandbox.allowSshAgent = false;
+
   # Meeting workspace support. Output names and camera identifiers are
   # machine-local; inspect them before replacing these null placeholders.
   # dotfiles.meeting.enable = false;
@@ -62,6 +73,7 @@
   # dotfiles.profiles.browser.enable = false;
   # dotfiles.profiles.micrantha.enable = false;
   # dotfiles.profiles.office.enable = false;
+  # dotfiles.profiles.workstation.enable = false;
 
   # Optional runtime path containing a GPG fingerprint. Do not place the key
   # itself or other secret material in this file.

--- a/home/ryjen/user.example.nix
+++ b/home/ryjen/user.example.nix
@@ -16,9 +16,9 @@
   };
 
   # Portable overrides. Tracked profiles provide defaults through mkDefault.
+  # Package implementation overrides intentionally remain tracked in modules.
   # dotfiles.agents.hermes.enable = false;
   # dotfiles.agents.antigravity.enable = false;
-  # dotfiles.agents.antigravity.package = null; # Replace with a package expression when overriding.
 
   # dotfiles.uv.enable = false;
   # dotfiles.uv.toolsFile = ".config/uv/tools.toml";
@@ -68,7 +68,6 @@
   # dotfiles.headroom.proxy.package = "${config.home.homeDirectory}/.local/libexec/headroom-proxy";
 
   # dotfiles.opsCadence.enable = false;
-  # dotfiles.opsCadence.package = null; # Replace with a package expression when overriding.
   # dotfiles.opsCadence.timers.enable = true;
 
   # Current grouped/profile selections. These remain listed until migrated to

--- a/home/ryjen/user.example.nix
+++ b/home/ryjen/user.example.nix
@@ -38,6 +38,7 @@
   # Set either value to false to disable that client independently.
 
   # dotfiles.music.enable = false;
+  # dotfiles.music.musicDirectory = "${config.home.homeDirectory}/Music";
   # dotfiles.grimblast.enable = false;
   # dotfiles.graphical.keyring.enable = false;
 
@@ -67,6 +68,7 @@
   # dotfiles.headroom.proxy.package = "${config.home.homeDirectory}/.local/libexec/headroom-proxy";
 
   # dotfiles.opsCadence.enable = false;
+  # dotfiles.opsCadence.package = null; # Replace with a package expression when overriding.
   # dotfiles.opsCadence.timers.enable = true;
 
   # Current grouped/profile selections. These remain listed until migrated to

--- a/home/ryjen/user.example.nix
+++ b/home/ryjen/user.example.nix
@@ -18,6 +18,7 @@
   # Portable overrides. Tracked profiles provide defaults through mkDefault.
   # dotfiles.agents.hermes.enable = false;
   # dotfiles.agents.antigravity.enable = false;
+  # dotfiles.agents.antigravity.package = null; # Replace with a package expression when overriding.
 
   # dotfiles.uv.enable = false;
   # dotfiles.uv.toolsFile = ".config/uv/tools.toml";

--- a/scripts/verify-user-option-catalog.py
+++ b/scripts/verify-user-option-catalog.py
@@ -27,6 +27,10 @@ CATALOG_OPTION = re.compile(r"dotfiles\.([A-Za-z][A-Za-z0-9_.-]*)\s*=")
 HOME_CONFIG = re.compile(r"mkHomeConfig\s+\./home/ryjen/([A-Za-z0-9_-]+\.nix)")
 LOCAL_IMPORT = "lib.optional (builtins.pathExists ./user.local.nix) ./user.local.nix"
 NON_PORTABLE_PREFIXES = ("host",)
+NON_PORTABLE_OPTIONS = {
+    "agents.antigravity.package",
+    "opsCadence.package",
+}
 
 
 def brace_delta(line: str) -> int:
@@ -90,6 +94,8 @@ def declared_option_paths(text: str) -> set[str]:
 
 
 def is_portable(path: str) -> bool:
+    if path in NON_PORTABLE_OPTIONS:
+        return False
     return not any(path == prefix or path.startswith(f"{prefix}.") for prefix in NON_PORTABLE_PREFIXES)
 
 

--- a/scripts/verify-user-option-catalog.py
+++ b/scripts/verify-user-option-catalog.py
@@ -12,6 +12,7 @@ OPTION_NAMESPACE = re.compile(r"options\.dotfiles\.([A-Za-z][A-Za-z0-9_-]*)")
 CATALOG_NAMESPACE = re.compile(r"dotfiles\.([A-Za-z][A-Za-z0-9_-]*)\.")
 HOME_CONFIG = re.compile(r"mkHomeConfig\s+\./home/ryjen/([A-Za-z0-9_-]+\.nix)")
 LOCAL_IMPORT = "lib.optional (builtins.pathExists ./user.local.nix) ./user.local.nix"
+NON_PORTABLE_NAMESPACES = {"host"}
 
 
 def fail(messages: list[str]) -> None:
@@ -30,10 +31,11 @@ def main() -> None:
     declared: set[str] = set()
     for path in sorted(modules.rglob("*.nix")):
         declared.update(OPTION_NAMESPACE.findall(path.read_text(encoding="utf-8")))
+    portable = declared - NON_PORTABLE_NAMESPACES
 
     catalog_text = catalog_path.read_text(encoding="utf-8")
     catalogued = set(CATALOG_NAMESPACE.findall(catalog_text))
-    missing = sorted(declared - catalogued)
+    missing = sorted(portable - catalogued)
     if missing:
         errors.append(
             "user.example.nix is missing dotfiles option namespaces: " + ", ".join(missing)
@@ -57,7 +59,7 @@ def main() -> None:
         fail(errors)
 
     print(
-        f"user option catalog covers {len(declared)} namespaces across "
+        f"user option catalog covers {len(portable)} portable namespaces across "
         f"{len(configs)} Home Manager outputs"
     )
 

--- a/scripts/verify-user-option-catalog.py
+++ b/scripts/verify-user-option-catalog.py
@@ -8,11 +8,75 @@ import sys
 from pathlib import Path
 
 
-OPTION_NAMESPACE = re.compile(r"options\.dotfiles\.([A-Za-z][A-Za-z0-9_-]*)")
-CATALOG_NAMESPACE = re.compile(r"dotfiles\.([A-Za-z][A-Za-z0-9_-]*)\.")
+OPTION_CONSTRUCTOR = r"lib\.mk(?:EnableOption|Option)\b"
+DIRECT_OPTION = re.compile(
+    rf"^\s*options\.dotfiles\.([A-Za-z][A-Za-z0-9_.-]*)\s*=\s*{OPTION_CONSTRUCTOR}"
+)
+OPTIONS_BLOCK = re.compile(
+    r"^\s*options\.dotfiles(?:\.([A-Za-z][A-Za-z0-9_.-]*))?\s*=\s*\{\s*$"
+)
+NESTED_BLOCK = re.compile(r"^\s*([A-Za-z][A-Za-z0-9_.-]*)\s*=\s*\{\s*$")
+NESTED_OPTION = re.compile(
+    rf"^\s*([A-Za-z][A-Za-z0-9_.-]*)\s*=\s*{OPTION_CONSTRUCTOR}"
+)
+CATALOG_OPTION = re.compile(r"dotfiles\.([A-Za-z][A-Za-z0-9_.-]*)\s*=")
 HOME_CONFIG = re.compile(r"mkHomeConfig\s+\./home/ryjen/([A-Za-z0-9_-]+\.nix)")
 LOCAL_IMPORT = "lib.optional (builtins.pathExists ./user.local.nix) ./user.local.nix"
-NON_PORTABLE_NAMESPACES = {"host"}
+NON_PORTABLE_PREFIXES = ("host",)
+
+
+def brace_delta(line: str) -> int:
+    """Count structural braces after removing comments and quoted strings."""
+    code = line.split("#", 1)[0]
+    code = re.sub(r'"(?:\\.|[^"\\])*"', '""', code)
+    return code.count("{") - code.count("}")
+
+
+def join_path(prefix: tuple[str, ...], suffix: str) -> str:
+    return ".".join((*prefix, *suffix.split(".")))
+
+
+def declared_option_paths(text: str) -> set[str]:
+    """Extract exact dotfiles option paths from nixfmt-formatted module declarations."""
+    declared: set[str] = set()
+    depth = 0
+    scopes: list[tuple[int, tuple[str, ...]]] = []
+
+    for raw_line in text.splitlines():
+        line = raw_line.split("#", 1)[0].rstrip()
+
+        while scopes and depth < scopes[-1][0]:
+            scopes.pop()
+
+        direct = DIRECT_OPTION.match(line)
+        if direct:
+            declared.add(direct.group(1))
+
+        block = OPTIONS_BLOCK.match(line)
+        if block:
+            prefix = tuple((block.group(1) or "").split(".")) if block.group(1) else ()
+            next_depth = depth + brace_delta(line)
+            scopes.append((next_depth, prefix))
+        elif scopes:
+            prefix = scopes[-1][1]
+            option = NESTED_OPTION.match(line)
+            if option:
+                declared.add(join_path(prefix, option.group(1)))
+            else:
+                nested = NESTED_BLOCK.match(line)
+                if nested:
+                    next_depth = depth + brace_delta(line)
+                    scopes.append((next_depth, tuple(join_path(prefix, nested.group(1)).split("."))))
+
+        depth += brace_delta(line)
+        while scopes and depth < scopes[-1][0]:
+            scopes.pop()
+
+    return declared
+
+
+def is_portable(path: str) -> bool:
+    return not any(path == prefix or path.startswith(f"{prefix}.") for prefix in NON_PORTABLE_PREFIXES)
 
 
 def fail(messages: list[str]) -> None:
@@ -30,16 +94,18 @@ def main() -> None:
     errors: list[str] = []
     declared: set[str] = set()
     for path in sorted(modules.rglob("*.nix")):
-        declared.update(OPTION_NAMESPACE.findall(path.read_text(encoding="utf-8")))
-    portable = declared - NON_PORTABLE_NAMESPACES
+        declared.update(declared_option_paths(path.read_text(encoding="utf-8")))
+    portable = {path for path in declared if is_portable(path)}
 
     catalog_text = catalog_path.read_text(encoding="utf-8")
-    catalogued = set(CATALOG_NAMESPACE.findall(catalog_text))
+    catalogued = set(CATALOG_OPTION.findall(catalog_text))
     missing = sorted(portable - catalogued)
     if missing:
-        errors.append(
-            "user.example.nix is missing dotfiles option namespaces: " + ", ".join(missing)
-        )
+        errors.append("user.example.nix is missing portable options: " + ", ".join(missing))
+
+    stale = sorted(catalogued - portable)
+    if stale:
+        errors.append("user.example.nix contains unknown or non-portable options: " + ", ".join(stale))
 
     flake_text = flake_path.read_text(encoding="utf-8")
     configs = sorted(set(HOME_CONFIG.findall(flake_text)))
@@ -59,7 +125,7 @@ def main() -> None:
         fail(errors)
 
     print(
-        f"user option catalog covers {len(portable)} portable namespaces across "
+        f"user option catalog covers {len(portable)} exact portable options across "
         f"{len(configs)} Home Manager outputs"
     )
 

--- a/scripts/verify-user-option-catalog.py
+++ b/scripts/verify-user-option-catalog.py
@@ -12,6 +12,10 @@ OPTION_CONSTRUCTOR = r"lib\.mk(?:EnableOption|Option)\b"
 DIRECT_OPTION = re.compile(
     rf"^\s*options\.dotfiles\.([A-Za-z][A-Za-z0-9_.-]*)\s*=\s*{OPTION_CONSTRUCTOR}"
 )
+DIRECT_OPTION_PREFIX = re.compile(
+    r"^\s*options\.dotfiles\.([A-Za-z][A-Za-z0-9_.-]*)\s*=\s*$"
+)
+CONSTRUCTOR_LINE = re.compile(rf"^\s*{OPTION_CONSTRUCTOR}")
 OPTIONS_BLOCK = re.compile(
     r"^\s*options\.dotfiles(?:\.([A-Za-z][A-Za-z0-9_.-]*))?\s*=\s*\{\s*$"
 )
@@ -41,9 +45,15 @@ def declared_option_paths(text: str) -> set[str]:
     declared: set[str] = set()
     depth = 0
     scopes: list[tuple[int, tuple[str, ...]]] = []
+    pending_direct: str | None = None
 
     for raw_line in text.splitlines():
         line = raw_line.split("#", 1)[0].rstrip()
+
+        if pending_direct is not None and line.strip():
+            if CONSTRUCTOR_LINE.match(line):
+                declared.add(pending_direct)
+            pending_direct = None
 
         while scopes and depth < scopes[-1][0]:
             scopes.pop()
@@ -51,6 +61,10 @@ def declared_option_paths(text: str) -> set[str]:
         direct = DIRECT_OPTION.match(line)
         if direct:
             declared.add(direct.group(1))
+        else:
+            direct_prefix = DIRECT_OPTION_PREFIX.match(line)
+            if direct_prefix:
+                pending_direct = direct_prefix.group(1)
 
         block = OPTIONS_BLOCK.match(line)
         if block:

--- a/scripts/verify-user-option-catalog.py
+++ b/scripts/verify-user-option-catalog.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Verify the portable Home Manager option catalog and local import contract."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+OPTION_NAMESPACE = re.compile(r"options\.dotfiles\.([A-Za-z][A-Za-z0-9_-]*)")
+CATALOG_NAMESPACE = re.compile(r"dotfiles\.([A-Za-z][A-Za-z0-9_-]*)\.")
+HOME_CONFIG = re.compile(r"mkHomeConfig\s+\./home/ryjen/([A-Za-z0-9_-]+\.nix)")
+LOCAL_IMPORT = "lib.optional (builtins.pathExists ./user.local.nix) ./user.local.nix"
+
+
+def fail(messages: list[str]) -> None:
+    for message in messages:
+        print(f"error: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def main() -> None:
+    root = Path(sys.argv[1] if len(sys.argv) > 1 else ".").resolve()
+    modules = root / "modules" / "home"
+    catalog_path = root / "home" / "ryjen" / "user.example.nix"
+    flake_path = root / "flake.nix"
+
+    errors: list[str] = []
+    declared: set[str] = set()
+    for path in sorted(modules.rglob("*.nix")):
+        declared.update(OPTION_NAMESPACE.findall(path.read_text(encoding="utf-8")))
+
+    catalog_text = catalog_path.read_text(encoding="utf-8")
+    catalogued = set(CATALOG_NAMESPACE.findall(catalog_text))
+    missing = sorted(declared - catalogued)
+    if missing:
+        errors.append(
+            "user.example.nix is missing dotfiles option namespaces: " + ", ".join(missing)
+        )
+
+    flake_text = flake_path.read_text(encoding="utf-8")
+    configs = sorted(set(HOME_CONFIG.findall(flake_text)))
+    for name in configs:
+        path = root / "home" / "ryjen" / name
+        text = path.read_text(encoding="utf-8")
+        if LOCAL_IMPORT not in text:
+            errors.append(f"{path.relative_to(root)} does not optionally import user.local.nix")
+
+    # The NixOS-integrated module imports dubnium-home.nix directly, so ensure
+    # it is covered even if its standalone homeConfiguration is later removed.
+    dubnium_home = root / "home" / "ryjen" / "dubnium-home.nix"
+    if LOCAL_IMPORT not in dubnium_home.read_text(encoding="utf-8"):
+        errors.append("home/ryjen/dubnium-home.nix does not optionally import user.local.nix")
+
+    if errors:
+        fail(errors)
+
+    print(
+        f"user option catalog covers {len(declared)} namespaces across "
+        f"{len(configs)} Home Manager outputs"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify-user-option-catalog.py
+++ b/scripts/verify-user-option-catalog.py
@@ -28,6 +28,8 @@ HOME_CONFIG = re.compile(r"mkHomeConfig\s+\./home/ryjen/([A-Za-z0-9_-]+\.nix)")
 LOCAL_IMPORT = "lib.optional (builtins.pathExists ./user.local.nix) ./user.local.nix"
 NON_PORTABLE_PREFIXES = ("host",)
 NON_PORTABLE_OPTIONS = {
+    # Package-valued implementation injection points are supplied by tracked
+    # modules and flake inputs, not by portable user selection files.
     "agents.antigravity.package",
     "opsCadence.package",
 }


### PR DESCRIPTION
## Summary

- complete `home/ryjen/user.example.nix` for recently added portable selections, including OpenWork sandbox controls and desktop profile variants
- make the `meeting-verify` Home Manager output optionally import ignored `user.local.nix`, matching every other output
- add a dependency-free verifier that compares declared portable `dotfiles.*` namespaces with the canonical example catalog
- verify every `mkHomeConfig` output preserves the optional local import contract
- run the verifier in a bounded, read-only GitHub Actions workflow

## Security and ownership

- host identity and host capability options remain tracked and are explicitly excluded from the portable catalog
- `user.local.nix` remains ignored and is only included through `path:$PWD` flake evaluation
- the CI job has `contents: read`, no secrets, no generated writes, and a five-minute timeout

## Validation

- static catalog/import verifier
- existing Nix and Home Manager CI remains authoritative for evaluation

Closes #95