### PR TITLE
ci: restore authoritative flake validation

### DIFF
--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -22,15 +22,11 @@ jobs:
       - name: Validate Flake Metadata
         run: nix flake metadata --no-write-lock-file
 
+      - name: Run Canonical Flake Checks
+        run: nix flake check --print-build-logs
+
       - name: Build OpenWork Package
-        run: |
-          nix build --impure --expr '
-            let
-              flake = builtins.getFlake (toString ./.);
-              pkgs = import flake.inputs.nixpkgs { system = "x86_64-linux"; };
-            in
-            pkgs.callPackage ./packages/openwork.nix { }
-          '
+        run: nix build .#openwork
 
       - name: Build Home Manager Activation
         run: nix build .#homeConfigurations.ryjen@verify.activationPackage

--- a/flake.nix
+++ b/flake.nix
@@ -260,6 +260,7 @@
         };
 
       packages.${system} = {
+        openwork = pkgs.callPackage ./packages/openwork.nix { };
         hermes-agent = hermes-agent.packages.${system}.default;
         git-autocommit = git-autocommit.packages.${system}.default;
       };


### PR DESCRIPTION
## Summary

- run `nix flake check --print-build-logs` as the canonical repository correctness gate
- export OpenWork as `packages.x86_64-linux.openwork`
- replace the impure inline OpenWork expression with `nix build .#openwork`
- preserve the existing generic Home Manager and NixOS builds

## Scope

This is Slice 1 of #112. Workflow hardening, action SHA pinning, job splitting, profile coverage, trusted Dubnium integration, and change-aware gating remain follow-up slices.

## Validation

- CI will validate flake metadata
- CI will run all repository-defined flake checks
- CI will build the named OpenWork package
- CI will retain the generic Home Manager activation and NixOS system builds

Refs #112