### PR TITLE
ci: cancel superseded Nix CI runs

### DIFF
--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -6,6 +6,13 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   discover-checks:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds workflow-level concurrency control to `Nix CI` so a newer commit cancels the prior in-progress run for the same pull request.

Also makes the workflow's least-privilege permission explicit with `contents: read`.

## Why

Superseded pull-request runs currently continue provisioning the discovery job, repository-check matrix, pre-commit baseline, and final flake builds. This consumes runner capacity for commits that can no longer be merged.

Non-PR runs use `github.run_id`, so independent pushes to `main` are neither cancelled nor serialized.

## Changes

- add a stable concurrency group keyed by pull-request number;
- enable cancellation only for pull-request events;
- use the unique run ID outside pull requests;
- declare `contents: read` explicitly.

## Validation

- reviewed the GitHub Actions expression for PR and push event contexts;
- preserved all existing jobs, dependencies, triggers, and commands unchanged.

Closes the concurrency slice of #117.