### PR TITLE
feat(waybar): add visible music seek controls

### DIFF
--- a/files/home/.config/waybar/config.jsonc
+++ b/files/home/.config/waybar/config.jsonc
@@ -19,7 +19,9 @@
         "hyprland/window"
     ],
     "modules-right": [
+        "custom/music-seek-backward",
         "custom/music",
+        "custom/music-seek-forward",
         "idle_inhibitor",
         "pulseaudio",
         "power-profiles-daemon",
@@ -112,6 +114,11 @@
         "on-click": "blueman-manager",
         "on-click-right": "bluetoothctl power $(bluetoothctl show | awk '/Powered:/{print $2}' | grep -q yes && echo off || echo on)"
     },
+    "custom/music-seek-backward": {
+        "format": "<",
+        "tooltip-format": "Seek backward 10 seconds",
+        "on-click": "playerctl --player=mpv position 10-"
+    },
     "custom/music": {
         "exec": "~/.local/bin/music-status",
         "interval": 1,
@@ -123,6 +130,11 @@
         "on-click-middle": "playerctl --player=mpv previous",
         "on-click-backward": "~/.local/bin/music-eq",
         "on-click-forward": "~/.local/bin/music-eq service"
+    },
+    "custom/music-seek-forward": {
+        "format": ">",
+        "tooltip-format": "Seek forward 10 seconds",
+        "on-click": "playerctl --player=mpv position 10+"
     },
     "pulseaudio": {
         "format": "{volume}% {icon}  {format_source}",


### PR DESCRIPTION
## Summary

- add visible `<` and `>` controls around the Dubnium Waybar music status
- seek backward or forward by 10 seconds within the current track
- preserve the existing mouse bindings for previous/next track and EQ controls

## Behavior

- `<`: `playerctl --player=mpv position 10-`
- `>`: `playerctl --player=mpv position 10+`

## Scope

This intentionally updates the active Dubnium Waybar profile only. The Technetium profile remains unchanged.