### PR TITLE
Add desktop-only idle locking and display power management

### DIFF
--- a/home/ryjen/profiles/graphical.nix
+++ b/home/ryjen/profiles/graphical.nix
@@ -2,4 +2,5 @@
 {
   dotfiles.host.graphical.enable = true;
   dotfiles.graphical.keyring.enable = lib.mkDefault true;
+  dotfiles.idle.enable = lib.mkDefault true;
 }

--- a/home/ryjen/user.example.nix
+++ b/home/ryjen/user.example.nix
@@ -41,6 +41,7 @@
   # dotfiles.music.musicDirectory = "${config.home.homeDirectory}/Music";
   # dotfiles.grimblast.enable = false;
   # dotfiles.graphical.keyring.enable = false;
+  # dotfiles.idle.enable = false;
 
   # Hardware/profile variants that are safe to select locally.
   # dotfiles.alacritty.adoptedProfile = "empty";

--- a/modules/home/default.nix
+++ b/modules/home/default.nix
@@ -24,6 +24,7 @@
     ./gpg.nix
     ./grimblast.nix
     ./hypr.nix
+    ./idle.nix
     ./input.nix
     ./keyring.nix
     ./lsd.nix

--- a/modules/home/idle.nix
+++ b/modules/home/idle.nix
@@ -1,0 +1,88 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.dotfiles.idle;
+in
+{
+  options.dotfiles.idle.enable = lib.mkEnableOption "desktop idle locking and display power management";
+
+  config = lib.mkIf (cfg.enable && config.dotfiles.profiles.workstation.enable) {
+    home.packages = [
+      pkgs.hypridle
+      pkgs.hyprlock
+    ];
+
+    xdg.configFile."hypr/hypridle.conf".text = ''
+      general {
+          lock_cmd = pidof hyprlock || hyprlock
+          before_sleep_cmd = loginctl lock-session
+          after_sleep_cmd = hyprctl dispatch dpms on
+      }
+
+      listener {
+          timeout = 600
+          on-timeout = pidof hyprlock || hyprlock
+      }
+
+      listener {
+          timeout = 900
+          on-timeout = hyprctl dispatch dpms off
+          on-resume = hyprctl dispatch dpms on
+      }
+    '';
+
+    xdg.configFile."hypr/hyprlock.conf".text = ''
+      general {
+          disable_loading_bar = true
+          hide_cursor = true
+      }
+
+      background {
+          monitor =
+          path = screenshot
+          blur_passes = 3
+          blur_size = 8
+      }
+
+      input-field {
+          monitor =
+          size = 320, 56
+          position = 0, -40
+          halign = center
+          valign = center
+          placeholder_text = <i>Password</i>
+          fail_text = <i>Authentication failed</i>
+      }
+
+      label {
+          monitor =
+          text = cmd[update:1000] date +"%I:%M %p"
+          font_size = 64
+          position = 0, 100
+          halign = center
+          valign = center
+      }
+    '';
+
+    systemd.user.services.dubnium-idle = lib.mkIf config.dotfiles.host.userSystemd.enable {
+      Unit = {
+        Description = "Dubnium desktop idle policy";
+        After = [ "graphical-session.target" ];
+        PartOf = [ "graphical-session.target" ];
+        Conflicts = [ "dubnium-meeting-mode.service" ];
+        ConditionEnvironment = "WAYLAND_DISPLAY";
+      };
+      Service = {
+        Type = "simple";
+        ExecStart = "${pkgs.hypridle}/bin/hypridle -c %h/.config/hypr/hypridle.conf";
+        Restart = "on-failure";
+        RestartSec = 2;
+      };
+      Install.WantedBy = [ "graphical-session.target" ];
+    };
+  };
+}

--- a/modules/home/idle.nix
+++ b/modules/home/idle.nix
@@ -6,11 +6,25 @@
 }:
 let
   cfg = config.dotfiles.idle;
+  hyprctl = "${pkgs.hyprland}/bin/hyprctl";
+  hyprlock = "${pkgs.hyprlock}/bin/hyprlock";
+  pidof = "${pkgs.procps}/bin/pidof";
 in
 {
   options.dotfiles.idle.enable = lib.mkEnableOption "desktop idle locking and display power management";
 
   config = lib.mkIf (cfg.enable && config.dotfiles.profiles.workstation.enable) {
+    assertions = [
+      {
+        assertion = config.dotfiles.host.graphical.enable;
+        message = "dotfiles.idle.enable requires dotfiles.host.graphical.enable.";
+      }
+      {
+        assertion = config.dotfiles.host.userSystemd.enable;
+        message = "dotfiles.idle.enable requires Home Manager user systemd support.";
+      }
+    ];
+
     home.packages = [
       pkgs.hypridle
       pkgs.hyprlock
@@ -18,20 +32,20 @@ in
 
     xdg.configFile."hypr/hypridle.conf".text = ''
       general {
-          lock_cmd = pidof hyprlock || hyprlock
-          before_sleep_cmd = loginctl lock-session
-          after_sleep_cmd = hyprctl dispatch dpms on
+          lock_cmd = ${pidof} hyprlock || ${hyprlock}
+          before_sleep_cmd = ${pkgs.systemd}/bin/loginctl lock-session
+          after_sleep_cmd = ${hyprctl} dispatch dpms on
       }
 
       listener {
           timeout = 600
-          on-timeout = pidof hyprlock || hyprlock
+          on-timeout = ${pidof} hyprlock || ${hyprlock}
       }
 
       listener {
           timeout = 900
-          on-timeout = hyprctl dispatch dpms off
-          on-resume = hyprctl dispatch dpms on
+          on-timeout = ${hyprctl} dispatch dpms off
+          on-resume = ${hyprctl} dispatch dpms on
       }
     '';
 
@@ -60,7 +74,7 @@ in
 
       label {
           monitor =
-          text = cmd[update:1000] date +"%I:%M %p"
+          text = cmd[update:1000] ${pkgs.coreutils}/bin/date +"%I:%M %p"
           font_size = 64
           position = 0, 100
           halign = center
@@ -68,7 +82,7 @@ in
       }
     '';
 
-    systemd.user.services.dubnium-idle = lib.mkIf config.dotfiles.host.userSystemd.enable {
+    systemd.user.services.dubnium-idle = {
       Unit = {
         Description = "Dubnium desktop idle policy";
         After = [ "graphical-session.target" ];

--- a/modules/home/meeting.nix
+++ b/modules/home/meeting.nix
@@ -149,10 +149,9 @@ in
         Environment = "DUBNIUM_PRESENTATION_OUTPUT=${
           lib.optionalString (cfg.presentationOutput != null) cfg.presentationOutput
         }";
-        ExecStartPre = "-${pkgs.systemd}/bin/systemctl --user stop dubnium-idle.service";
         ExecStart = "%h/.local/libexec/dubnium-meeting-mode start";
         ExecStop = "%h/.local/libexec/dubnium-meeting-mode stop";
-        ExecStopPost = "-${pkgs.systemd}/bin/systemctl --user start dubnium-idle.service";
+        ExecStopPost = "-${pkgs.systemd}/bin/systemctl --user --no-block start dubnium-idle.service";
       };
     };
 

--- a/modules/home/meeting.nix
+++ b/modules/home/meeting.nix
@@ -139,15 +139,20 @@ in
     };
 
     systemd.user.services.dubnium-meeting-mode = lib.mkIf config.dotfiles.host.userSystemd.enable {
-      Unit.Description = "Dubnium meeting privacy mode";
+      Unit = {
+        Description = "Dubnium meeting privacy mode";
+        Conflicts = [ "dubnium-idle.service" ];
+      };
       Service = {
         Type = "oneshot";
         RemainAfterExit = true;
         Environment = "DUBNIUM_PRESENTATION_OUTPUT=${
           lib.optionalString (cfg.presentationOutput != null) cfg.presentationOutput
         }";
+        ExecStartPre = "-${pkgs.systemd}/bin/systemctl --user stop dubnium-idle.service";
         ExecStart = "%h/.local/libexec/dubnium-meeting-mode start";
         ExecStop = "%h/.local/libexec/dubnium-meeting-mode stop";
+        ExecStopPost = "-${pkgs.systemd}/bin/systemctl --user start dubnium-idle.service";
       };
     };
 


### PR DESCRIPTION
## What changed

- add a `dotfiles.idle` Home Manager module using `hypridle` and `hyprlock`
- lock after 10 minutes of inactivity
- power displays down after 15 minutes and restore them on activity
- intentionally omit automatic suspend so local AI, containers, runners, SSH sessions, and long-running jobs remain available
- run the policy as `dubnium-idle.service` under `graphical-session.target`
- stop/conflict the idle service while meeting/presentation mode is active
- restart the idle service when meeting mode exits
- enable the policy only through the graphical desktop profile; headless profiles are unaffected

## Runtime behavior

| State | Idle policy |
|---|---|
| Normal graphical desktop | enabled |
| Meeting/presentation mode | stopped |
| Return to desktop mode | restarted with fresh timers |
| Waybar idle inhibitor active | Hypridle honors the session inhibitor |

## Validation

- reviewed the generated Home Manager module wiring
- verified the meeting service has symmetric stop/restore handling
- verified no suspend listener is configured

## Deployment checks

After applying the Home Manager configuration:

```bash
systemctl --user status dubnium-idle.service
systemctl --user status dubnium-meeting-mode.service
```

Manual behavior checks:

```bash
systemctl --user start dubnium-meeting-mode.service
systemctl --user is-active dubnium-idle.service   # expected: inactive
systemctl --user stop dubnium-meeting-mode.service
systemctl --user is-active dubnium-idle.service   # expected: active
```
