### PR TITLE
feat(alacritty): simplify clipboard shortcuts

### DIFF
--- a/files/home/.config/alacritty/conf.d/base.toml
+++ b/files/home/.config/alacritty/conf.d/base.toml
@@ -19,3 +19,11 @@ style = "Italic"
 [font.bold_italic]
 family = "Hack Nerd Font Mono"
 style = "Bold Italic"
+
+[selection]
+save_to_clipboard = true
+
+[keyboard]
+bindings = [
+  { key = "V", mods = "Control", action = "Paste" },
+]


### PR DESCRIPTION
## Summary

- automatically copy selected terminal text to the system clipboard
- bind `Ctrl+V` to paste from the clipboard
- preserve normal `Ctrl+C` interrupt behavior
- retain `Ctrl+Shift+C` as Alacritty's existing explicit copy shortcut

## Why

This removes the most common terminal clipboard friction without overriding `Ctrl+C`, which must remain available to send `SIGINT` to foreground processes.

## Scope

The change is applied in the managed shared Alacritty base fragment, so it applies consistently across workstation profiles while later local/custom fragments can still override it.

## Validation

- configuration uses supported Alacritty TOML sections and actions
- no shell key bindings or terminal interrupt semantics are changed
- change is limited to the Alacritty base fragment
