### PR TITLE
Add gdu and weekly Nix cleanup

### DIFF
--- a/modules/home/devtools.nix
+++ b/modules/home/devtools.nix
@@ -4,6 +4,7 @@
     pkgs.cmake
     pkgs.ffmpeg
     pkgs.gcc
+    pkgs.gdu
     pkgs.gh
     pkgs.git
     pkgs.gnumake

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -7,6 +7,7 @@
     ./audio.nix
     ./bluetooth.nix
     ./fonts.nix
+    ./maintenance.nix
     ./motd.nix
     ./podman.nix
     ./shell.nix

--- a/modules/nixos/maintenance.nix
+++ b/modules/nixos/maintenance.nix
@@ -1,0 +1,10 @@
+{ ... }:
+{
+  nix.gc = {
+    automatic = true;
+    dates = "weekly";
+    options = "--delete-older-than 14d";
+    persistent = true;
+    randomizedDelaySec = "1h";
+  };
+}


### PR DESCRIPTION
## Summary

- add `gdu` to the shared Home Manager developer tools
- add a native NixOS garbage-collection timer
- run cleanup weekly, retain generations newer than 14 days, and catch up after downtime
- randomize execution by up to one hour to avoid a fixed maintenance spike

## Rationale

`gdu` provides an interactive, low-dependency disk usage analyzer with deletion support. The cleanup policy uses NixOS's built-in `nix.gc` service rather than a custom shell script, keeping the configuration declarative and observable through systemd.

The 14-day retention window reclaims stale store paths while preserving a practical rollback window. Files under `/nix/store` must still not be deleted manually.

## Validation

- reviewed the branch diff against `main`
- confirmed the branch is three commits ahead with only the intended Home Manager and NixOS module changes
- CI should evaluate the NixOS options and package availability