### PR TITLE
perf: add measured Dubnium Nix build benchmark

### DIFF
--- a/docs/nix-build-performance.md
+++ b/docs/nix-build-performance.md
@@ -1,0 +1,64 @@
+# Dubnium Nix build performance benchmarks
+
+The benchmark harness measures the tracked Dubnium Home Manager activation
+package without clearing caches, garbage-collecting the store, or activating a
+generation unless explicitly requested.
+
+## Commands
+
+```bash
+# Evaluation plus a dry-run realization plan
+nix run .#benchmark-dubnium -- plan --repeat 3
+
+# Measure evaluation and realization independently
+nix run .#benchmark-dubnium -- build --repeat 3
+
+# Run one plan followed by repeated build measurements
+nix run .#benchmark-dubnium -- suite --repeat 3 --json result.json
+
+# Explicitly realize and activate; defaults to one activation
+nix run .#benchmark-dubnium -- activate
+```
+
+The target must be a local output beginning with `.#`. Commands and Git
+provenance are evaluated relative to `--flake-dir`, which defaults to the
+current directory. External flake targets are rejected so benchmark results
+cannot accidentally claim provenance from an unrelated checkout.
+
+## Output contract
+
+Stdout contains exactly one JSON document. Nix and activation diagnostics are
+left on stderr, so this remains valid:
+
+```bash
+nix run .#benchmark-dubnium -- build --repeat 3 | jq .summary
+```
+
+The result records:
+
+- separate evaluation, realization, planning, and activation samples;
+- individual samples and median/minimum/maximum summaries;
+- the Git revision and dirty state when available;
+- Nix version and scheduler settings;
+- a fingerprint and count for substituters rather than cache URLs;
+- platform, architecture, and CPU count.
+
+Literal hostnames are omitted by default. Use `--include-hostname` only for a
+result that will remain private.
+
+## Baseline procedure
+
+Collect at least three samples for each representative scenario:
+
+1. warm/no-op `build`;
+2. a small tracked Home Manager configuration change;
+3. a representative custom-package source change;
+4. optional cold or partial-cache measurements performed manually and
+   documented separately.
+
+Do not delete the Nix store or run garbage collection as part of the benchmark.
+A cold experiment should use an isolated store or an explicitly documented
+machine state rather than destructively modifying the workstation.
+
+Attach the JSON result and a brief description of machine activity to issue
+#124. Keep CPU-intensive unrelated work idle so comparisons remain meaningful.

--- a/flake.nix
+++ b/flake.nix
@@ -112,6 +112,13 @@
     in
     {
       apps.${system} = {
+        benchmark-dubnium = {
+          type = "app";
+          program = "${pkgs.writeShellScript "benchmark-dubnium" ''
+            exec ${pkgs.python3}/bin/python3 ${./scripts/benchmark-nix-build.py} "$@"
+          ''}";
+        };
+
         verify-container = {
           type = "app";
           program = "${./scripts/verify-in-container.sh}";
@@ -140,6 +147,15 @@
       };
 
       checks.${system} = {
+        benchmark-nix-build-tests =
+          pkgs.runCommand "benchmark-nix-build-tests" { nativeBuildInputs = [ pkgs.python3 ]; }
+            ''
+              export PYTHONDONTWRITEBYTECODE=1
+              cd ${self}
+              python3 -m unittest discover -s tests -p 'test_benchmark_nix_build.py'
+              touch "$out"
+            '';
+
         flake-script-executables =
           pkgs.runCommand "flake-script-executables"
             {

--- a/scripts/benchmark-nix-build.py
+++ b/scripts/benchmark-nix-build.py
@@ -47,6 +47,7 @@ def run(
     command: Sequence[str],
     *,
     cwd: Path,
+    capture_stdout: bool = True,
     capture_stderr: bool = False,
     check: bool = False,
 ) -> subprocess.CompletedProcess[str]:
@@ -56,7 +57,7 @@ def run(
         cwd=cwd,
         check=check,
         text=True,
-        stdout=subprocess.PIPE,
+        stdout=subprocess.PIPE if capture_stdout else sys.stderr,
         stderr=subprocess.PIPE if capture_stderr else None,
         env=os.environ.copy(),
     )
@@ -171,11 +172,12 @@ def timed_command(
     command: Sequence[str],
     *,
     cwd: Path,
+    capture_stdout: bool = False,
 ) -> Measurement:
     started = time.perf_counter()
     stdout = ""
     try:
-        completed = run(command, cwd=cwd)
+        completed = run(command, cwd=cwd, capture_stdout=capture_stdout)
         exit_code = completed.returncode
         stdout = completed.stdout
     except OSError as error:
@@ -217,6 +219,7 @@ def evaluate_target(
         iteration,
         evaluation_command(target),
         cwd=cwd,
+        capture_stdout=True,
     )
     sample = measurement.sample
     if sample.exit_code != 0:
@@ -252,6 +255,7 @@ def realize_drv(
         iteration,
         realization_command(drv_path),
         cwd=cwd,
+        capture_stdout=True,
     )
     sample = measurement.sample
     if sample.exit_code != 0:
@@ -414,20 +418,22 @@ def validate_args(args: argparse.Namespace, repeat: int) -> str | None:
 
 def atomic_write_json(path: Path, payload: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.NamedTemporaryFile(
-        mode="w",
-        encoding="utf-8",
-        dir=path.parent,
-        prefix=f".{path.name}.",
-        suffix=".tmp",
-        delete=False,
-    ) as temporary:
-        temporary.write(payload)
-        temporary_path = Path(temporary.name)
+    temporary_path: Path | None = None
     try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary:
+            temporary_path = Path(temporary.name)
+            temporary.write(payload)
         temporary_path.replace(path)
     except OSError:
-        temporary_path.unlink(missing_ok=True)
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
         raise
 
 

--- a/scripts/benchmark-nix-build.py
+++ b/scripts/benchmark-nix-build.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python3
-"""Benchmark Nix evaluation/build and optional Home Manager activation phases.
+"""Benchmark Nix evaluation, realization, and optional activation phases.
 
-The harness is intentionally non-destructive by default: it does not garbage
-collect, delete store paths, mutate configuration, or activate a generation
+The harness is non-destructive by default. It never garbage-collects, deletes
+store paths, mutates configuration, or activates a Home Manager generation
 unless the caller explicitly selects the ``activate`` phase.
+
+Stdout is reserved for the final JSON document. Child process diagnostics are
+written to stderr so results remain safe to pipe to tools such as ``jq``.
 """
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import platform
@@ -17,11 +21,12 @@ import subprocess
 import sys
 import tempfile
 import time
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, replace
 from pathlib import Path
 from typing import Any, Sequence
 
 DEFAULT_TARGET = '.#homeConfigurations."ryjen@dubnium".activationPackage'
+MAX_REPEAT = 20
 
 
 @dataclass(frozen=True)
@@ -32,131 +37,305 @@ class Sample:
     exit_code: int
 
 
+@dataclass(frozen=True)
+class Measurement:
+    sample: Sample
+    stdout: str
+
+
 def run(
     command: Sequence[str],
     *,
-    capture: bool = False,
+    cwd: Path,
+    capture_stderr: bool = False,
     check: bool = False,
 ) -> subprocess.CompletedProcess[str]:
+    """Run a command while keeping stdout out of the benchmark JSON stream."""
     return subprocess.run(
         list(command),
+        cwd=cwd,
         check=check,
         text=True,
-        stdout=subprocess.PIPE if capture else None,
-        stderr=subprocess.PIPE if capture else None,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE if capture_stderr else None,
         env=os.environ.copy(),
     )
 
 
-def capture(command: Sequence[str], fallback: str = "unknown") -> str:
+def capture_status(
+    command: Sequence[str],
+    *,
+    cwd: Path,
+) -> tuple[bool, str | None]:
     try:
-        completed = run(command, capture=True, check=True)
+        completed = run(command, cwd=cwd, capture_stderr=True, check=True)
     except (OSError, subprocess.CalledProcessError):
-        return fallback
-    return completed.stdout.strip() or fallback
+        return False, None
+    return True, completed.stdout.strip()
 
 
-def repository_metadata() -> dict[str, Any]:
-    revision = capture(["git", "rev-parse", "HEAD"])
-    dirty_output = capture(["git", "status", "--porcelain"], fallback="")
+def capture(command: Sequence[str], *, cwd: Path) -> str | None:
+    succeeded, value = capture_status(command, cwd=cwd)
+    if not succeeded or not value:
+        return None
+    return value
+
+
+def repository_metadata(cwd: Path) -> dict[str, Any]:
+    revision_available, revision = capture_status(
+        ["git", "rev-parse", "HEAD"],
+        cwd=cwd,
+    )
+    status_available, dirty_output = capture_status(
+        ["git", "status", "--porcelain"],
+        cwd=cwd,
+    )
     return {
-        "revision": revision,
-        "dirty": bool(dirty_output),
+        "available": revision_available and status_available,
+        "revision": revision if revision_available and revision else None,
+        "dirty": bool(dirty_output) if status_available else None,
     }
 
 
-def nix_metadata() -> dict[str, Any]:
-    settings: dict[str, str] = {}
-    try:
-        completed = run(["nix", "show-config", "--json"], capture=True, check=True)
-        raw = json.loads(completed.stdout)
-        for key in ("max-jobs", "cores", "max-substitution-jobs", "substituters"):
-            value = raw.get(key)
-            if isinstance(value, dict) and "value" in value:
-                settings[key] = str(value["value"])
-            elif value is not None:
-                settings[key] = str(value)
-    except (OSError, subprocess.CalledProcessError, json.JSONDecodeError):
-        settings = {"error": "unable to read nix configuration"}
+def unwrap_nix_setting(value: Any) -> Any:
+    if isinstance(value, dict) and "value" in value:
+        return value["value"]
+    return value
+
+
+def substituter_fingerprint(value: Any) -> dict[str, Any]:
+    value = unwrap_nix_setting(value)
+    if isinstance(value, str):
+        substituters = value.split()
+    elif isinstance(value, list):
+        substituters = [str(item) for item in value]
+    elif value is None:
+        substituters = []
+    else:
+        substituters = [str(value)]
+
+    normalized = "\0".join(sorted(substituters)).encode("utf-8")
+    return {
+        "count": len(substituters),
+        "sha256": hashlib.sha256(normalized).hexdigest(),
+    }
+
+
+def read_nix_config(cwd: Path) -> dict[str, Any] | None:
+    commands = (
+        ["nix", "config", "show", "--json"],
+        ["nix", "show-config", "--json"],
+    )
+    for command in commands:
+        try:
+            completed = run(command, cwd=cwd, capture_stderr=True, check=True)
+            raw = json.loads(completed.stdout)
+        except (OSError, subprocess.CalledProcessError, json.JSONDecodeError):
+            continue
+        if isinstance(raw, dict):
+            return raw
+    return None
+
+
+def nix_metadata(cwd: Path) -> dict[str, Any]:
+    raw = read_nix_config(cwd)
+    if raw is None:
+        settings: dict[str, Any] = {
+            "available": False,
+            "max-jobs": None,
+            "cores": None,
+            "max-substitution-jobs": None,
+            "substituters": None,
+        }
+    else:
+        settings = {
+            "available": True,
+            "max-jobs": unwrap_nix_setting(raw.get("max-jobs")),
+            "cores": unwrap_nix_setting(raw.get("cores")),
+            "max-substitution-jobs": unwrap_nix_setting(
+                raw.get("max-substitution-jobs")
+            ),
+            # Preserve comparability without exposing cache URLs or credentials.
+            "substituters": substituter_fingerprint(raw.get("substituters")),
+        }
 
     return {
-        "version": capture(["nix", "--version"]),
+        "version": capture(["nix", "--version"], cwd=cwd),
         "settings": settings,
     }
 
 
-def timed_command(phase: str, iteration: int, command: Sequence[str]) -> Sample:
+def timed_command(
+    phase: str,
+    iteration: int,
+    command: Sequence[str],
+    *,
+    cwd: Path,
+) -> Measurement:
     started = time.perf_counter()
+    stdout = ""
     try:
-        completed = run(command)
+        completed = run(command, cwd=cwd)
         exit_code = completed.returncode
+        stdout = completed.stdout
     except OSError as error:
         print(f"failed to execute {command[0]}: {error}", file=sys.stderr)
         exit_code = 127
     elapsed = time.perf_counter() - started
-    return Sample(
-        phase=phase,
-        iteration=iteration,
-        elapsed_seconds=round(elapsed, 6),
-        exit_code=exit_code,
+    return Measurement(
+        sample=Sample(
+            phase=phase,
+            iteration=iteration,
+            elapsed_seconds=round(elapsed, 6),
+            exit_code=exit_code,
+        ),
+        stdout=stdout,
     )
 
 
-def build_command(target: str, out_link: Path | None = None) -> list[str]:
-    command = [
-        "nix",
-        "build",
-        target,
-        "--print-build-logs",
+def evaluation_command(target: str) -> list[str]:
+    return ["nix", "eval", "--raw", f"{target}.drvPath"]
+
+
+def plan_command(drv_path: str) -> list[str]:
+    return ["nix-store", "--realise", "--dry-run", drv_path]
+
+
+def realization_command(drv_path: str) -> list[str]:
+    return ["nix-store", "--realise", drv_path]
+
+
+def evaluate_target(
+    target: str,
+    iteration: int,
+    *,
+    cwd: Path,
+    phase: str = "evaluate",
+) -> tuple[Sample, str | None]:
+    measurement = timed_command(
+        phase,
+        iteration,
+        evaluation_command(target),
+        cwd=cwd,
+    )
+    sample = measurement.sample
+    if sample.exit_code != 0:
+        return sample, None
+
+    values = [line.strip() for line in measurement.stdout.splitlines() if line.strip()]
+    if (
+        len(values) != 1
+        or not values[0].startswith("/nix/store/")
+        or not values[0].endswith(".drv")
+    ):
+        print("Nix evaluation did not return exactly one derivation path", file=sys.stderr)
+        return replace(sample, exit_code=65), None
+    return sample, values[0]
+
+
+def parse_output_paths(stdout: str) -> list[str]:
+    return [
+        line.strip()
+        for line in stdout.splitlines()
+        if line.strip().startswith("/nix/store/")
     ]
-    if out_link is None:
-        command.append("--no-link")
-    else:
-        command.extend(["--out-link", str(out_link)])
-    return command
 
 
-def plan_command(target: str) -> list[str]:
-    return ["nix", "build", target, "--dry-run", "--no-link"]
+def realize_drv(
+    drv_path: str,
+    iteration: int,
+    *,
+    cwd: Path,
+) -> tuple[Sample, list[str]]:
+    measurement = timed_command(
+        "realize",
+        iteration,
+        realization_command(drv_path),
+        cwd=cwd,
+    )
+    sample = measurement.sample
+    if sample.exit_code != 0:
+        return sample, []
+    output_paths = parse_output_paths(measurement.stdout)
+    if not output_paths:
+        print("Nix realization returned no output paths", file=sys.stderr)
+        return replace(sample, exit_code=66), []
+    return sample, output_paths
 
 
-def benchmark_build(target: str, repeat: int) -> list[Sample]:
+def benchmark_build(target: str, repeat: int, *, cwd: Path) -> list[Sample]:
     samples: list[Sample] = []
     for iteration in range(1, repeat + 1):
-        samples.append(timed_command("build", iteration, build_command(target)))
-        if samples[-1].exit_code != 0:
+        evaluate_sample, drv_path = evaluate_target(target, iteration, cwd=cwd)
+        samples.append(evaluate_sample)
+        if drv_path is None:
+            break
+        realize_sample, _ = realize_drv(drv_path, iteration, cwd=cwd)
+        samples.append(realize_sample)
+        if realize_sample.exit_code != 0:
             break
     return samples
 
 
-def benchmark_plan(target: str) -> list[Sample]:
-    return [timed_command("plan", 1, plan_command(target))]
-
-
-def benchmark_activation(target: str, repeat: int) -> list[Sample]:
+def benchmark_plan(target: str, repeat: int, *, cwd: Path) -> list[Sample]:
     samples: list[Sample] = []
-    with tempfile.TemporaryDirectory(prefix="dotfiles-nix-benchmark-") as directory:
-        out_link = Path(directory) / "activation-package"
-        build_sample = timed_command("activation-build", 1, build_command(target, out_link))
-        samples.append(build_sample)
-        if build_sample.exit_code != 0:
-            return samples
+    for iteration in range(1, repeat + 1):
+        evaluate_sample, drv_path = evaluate_target(
+            target,
+            iteration,
+            cwd=cwd,
+            phase="plan-evaluate",
+        )
+        samples.append(evaluate_sample)
+        if drv_path is None:
+            break
+        plan_sample = timed_command(
+            "plan",
+            iteration,
+            plan_command(drv_path),
+            cwd=cwd,
+        ).sample
+        samples.append(plan_sample)
+        if plan_sample.exit_code != 0:
+            break
+    return samples
 
-        activation_program = out_link / "activate"
-        if not activation_program.is_file():
-            print(
-                f"activation program not found at {activation_program}",
-                file=sys.stderr,
-            )
-            samples.append(Sample("activate", 1, 0.0, 66))
-            return samples
 
-        for iteration in range(1, repeat + 1):
-            samples.append(
-                timed_command("activate", iteration, [str(activation_program)])
-            )
-            if samples[-1].exit_code != 0:
-                break
+def benchmark_activation(target: str, repeat: int, *, cwd: Path) -> list[Sample]:
+    samples: list[Sample] = []
+    evaluate_sample, drv_path = evaluate_target(target, 1, cwd=cwd)
+    samples.append(evaluate_sample)
+    if drv_path is None:
+        return samples
+
+    realize_sample, output_paths = realize_drv(drv_path, 1, cwd=cwd)
+    samples.append(realize_sample)
+    if realize_sample.exit_code != 0:
+        return samples
+    if len(output_paths) != 1:
+        print("activation package must have exactly one output path", file=sys.stderr)
+        samples.append(Sample("activate", 1, 0.0, 66))
+        return samples
+
+    activation_program = Path(output_paths[0]) / "activate"
+    if not activation_program.is_file():
+        print(
+            f"activation program not found beneath realized output: {activation_program.name}",
+            file=sys.stderr,
+        )
+        samples.append(Sample("activate", 1, 0.0, 66))
+        return samples
+
+    for iteration in range(1, repeat + 1):
+        activation_sample = timed_command(
+            "activate",
+            iteration,
+            [str(activation_program)],
+            cwd=cwd,
+        ).sample
+        samples.append(activation_sample)
+        if activation_sample.exit_code != 0:
+            break
     return samples
 
 
@@ -177,9 +356,9 @@ def summarize(samples: Sequence[Sample]) -> dict[str, Any]:
     }
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Benchmark Dubnium Nix build and activation phases",
+        description="Benchmark Dubnium Nix evaluation, realization, and activation",
     )
     parser.add_argument(
         "phase",
@@ -189,13 +368,19 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--target",
         default=DEFAULT_TARGET,
-        help=f"flake target (default: {DEFAULT_TARGET})",
+        help=f"local flake target (default: {DEFAULT_TARGET})",
+    )
+    parser.add_argument(
+        "--flake-dir",
+        type=Path,
+        default=Path("."),
+        help="tracked local flake directory used for commands and provenance",
     )
     parser.add_argument(
         "--repeat",
         type=int,
-        default=3,
-        help="number of build/activation samples (default: 3)",
+        default=None,
+        help="sample count; defaults to 1 for activate and 3 otherwise",
     )
     parser.add_argument(
         "--json",
@@ -203,49 +388,103 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         help="write the complete result as JSON",
     )
-    return parser.parse_args()
+    parser.add_argument(
+        "--include-hostname",
+        action="store_true",
+        help="include the literal hostname in output; omitted by default",
+    )
+    return parser.parse_args(argv)
 
 
-def main() -> int:
-    args = parse_args()
-    if args.repeat < 1 or args.repeat > 20:
-        print("--repeat must be between 1 and 20", file=sys.stderr)
+def effective_repeat(args: argparse.Namespace) -> int:
+    if args.repeat is not None:
+        return args.repeat
+    return 1 if args.phase == "activate" else 3
+
+
+def validate_args(args: argparse.Namespace, repeat: int) -> str | None:
+    if repeat < 1 or repeat > MAX_REPEAT:
+        return f"--repeat must be between 1 and {MAX_REPEAT}"
+    if not args.target.startswith(".#"):
+        return "--target must identify an output in --flake-dir and begin with '.#'"
+    if not args.flake_dir.is_dir():
+        return "--flake-dir must be an existing directory"
+    return None
+
+
+def atomic_write_json(path: Path, payload: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as temporary:
+        temporary.write(payload)
+        temporary_path = Path(temporary.name)
+    try:
+        temporary_path.replace(path)
+    except OSError:
+        temporary_path.unlink(missing_ok=True)
+        raise
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    repeat = effective_repeat(args)
+    error = validate_args(args, repeat)
+    if error is not None:
+        print(error, file=sys.stderr)
         return 64
 
+    cwd = args.flake_dir.resolve()
     samples: list[Sample] = []
     if args.phase in ("plan", "suite"):
-        samples.extend(benchmark_plan(args.target))
+        plan_repeat = 1 if args.phase == "suite" else repeat
+        samples.extend(benchmark_plan(args.target, plan_repeat, cwd=cwd))
     if args.phase in ("build", "suite") and all(s.exit_code == 0 for s in samples):
-        samples.extend(benchmark_build(args.target, args.repeat))
+        samples.extend(benchmark_build(args.target, repeat, cwd=cwd))
     if args.phase == "activate":
-        samples.extend(benchmark_activation(args.target, args.repeat))
+        samples.extend(benchmark_activation(args.target, repeat, cwd=cwd))
+
+    host: dict[str, Any] = {
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "cpu_count": os.cpu_count(),
+    }
+    if args.include_hostname:
+        host["hostname"] = platform.node()
 
     result = {
-        "schema_version": 1,
+        "schema_version": 2,
         "target": args.target,
+        "target_bound_to_repository": True,
         "requested_phase": args.phase,
-        "repeat": args.repeat,
+        "repeat": repeat,
         "timestamp_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
-        "host": {
-            "hostname": platform.node(),
-            "platform": platform.platform(),
-            "machine": platform.machine(),
-            "cpu_count": os.cpu_count(),
-        },
-        "repository": repository_metadata(),
-        "nix": nix_metadata(),
+        "host": host,
+        "repository": repository_metadata(cwd),
+        "nix": nix_metadata(cwd),
         "samples": [asdict(sample) for sample in samples],
         "summary": summarize(samples),
     }
 
-    print(json.dumps(result, indent=2, sort_keys=True))
+    payload = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    output_error = False
     if args.json_path is not None:
-        args.json_path.parent.mkdir(parents=True, exist_ok=True)
-        args.json_path.write_text(
-            json.dumps(result, indent=2, sort_keys=True) + "\n",
-            encoding="utf-8",
-        )
+        try:
+            atomic_write_json(args.json_path, payload)
+        except OSError as error:
+            print(f"unable to write JSON result: {error}", file=sys.stderr)
+            output_error = True
 
+    # Keep stdout machine-readable even when child commands or file writes fail.
+    sys.stdout.write(payload)
+
+    if output_error:
+        return 73
     return 0 if samples and all(sample.exit_code == 0 for sample in samples) else 1
 
 

--- a/scripts/benchmark-nix-build.py
+++ b/scripts/benchmark-nix-build.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Benchmark Nix evaluation/build and optional Home Manager activation phases.
+
+The harness is intentionally non-destructive by default: it does not garbage
+collect, delete store paths, mutate configuration, or activate a generation
+unless the caller explicitly selects the ``activate`` phase.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+DEFAULT_TARGET = '.#homeConfigurations."ryjen@dubnium".activationPackage'
+
+
+@dataclass(frozen=True)
+class Sample:
+    phase: str
+    iteration: int
+    elapsed_seconds: float
+    exit_code: int
+
+
+def run(
+    command: Sequence[str],
+    *,
+    capture: bool = False,
+    check: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(command),
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE if capture else None,
+        stderr=subprocess.PIPE if capture else None,
+        env=os.environ.copy(),
+    )
+
+
+def capture(command: Sequence[str], fallback: str = "unknown") -> str:
+    try:
+        completed = run(command, capture=True, check=True)
+    except (OSError, subprocess.CalledProcessError):
+        return fallback
+    return completed.stdout.strip() or fallback
+
+
+def repository_metadata() -> dict[str, Any]:
+    revision = capture(["git", "rev-parse", "HEAD"])
+    dirty_output = capture(["git", "status", "--porcelain"], fallback="")
+    return {
+        "revision": revision,
+        "dirty": bool(dirty_output),
+    }
+
+
+def nix_metadata() -> dict[str, Any]:
+    settings: dict[str, str] = {}
+    try:
+        completed = run(["nix", "show-config", "--json"], capture=True, check=True)
+        raw = json.loads(completed.stdout)
+        for key in ("max-jobs", "cores", "max-substitution-jobs", "substituters"):
+            value = raw.get(key)
+            if isinstance(value, dict) and "value" in value:
+                settings[key] = str(value["value"])
+            elif value is not None:
+                settings[key] = str(value)
+    except (OSError, subprocess.CalledProcessError, json.JSONDecodeError):
+        settings = {"error": "unable to read nix configuration"}
+
+    return {
+        "version": capture(["nix", "--version"]),
+        "settings": settings,
+    }
+
+
+def timed_command(phase: str, iteration: int, command: Sequence[str]) -> Sample:
+    started = time.perf_counter()
+    try:
+        completed = run(command)
+        exit_code = completed.returncode
+    except OSError as error:
+        print(f"failed to execute {command[0]}: {error}", file=sys.stderr)
+        exit_code = 127
+    elapsed = time.perf_counter() - started
+    return Sample(
+        phase=phase,
+        iteration=iteration,
+        elapsed_seconds=round(elapsed, 6),
+        exit_code=exit_code,
+    )
+
+
+def build_command(target: str, out_link: Path | None = None) -> list[str]:
+    command = [
+        "nix",
+        "build",
+        target,
+        "--print-build-logs",
+    ]
+    if out_link is None:
+        command.append("--no-link")
+    else:
+        command.extend(["--out-link", str(out_link)])
+    return command
+
+
+def plan_command(target: str) -> list[str]:
+    return ["nix", "build", target, "--dry-run", "--no-link"]
+
+
+def benchmark_build(target: str, repeat: int) -> list[Sample]:
+    samples: list[Sample] = []
+    for iteration in range(1, repeat + 1):
+        samples.append(timed_command("build", iteration, build_command(target)))
+        if samples[-1].exit_code != 0:
+            break
+    return samples
+
+
+def benchmark_plan(target: str) -> list[Sample]:
+    return [timed_command("plan", 1, plan_command(target))]
+
+
+def benchmark_activation(target: str, repeat: int) -> list[Sample]:
+    samples: list[Sample] = []
+    with tempfile.TemporaryDirectory(prefix="dotfiles-nix-benchmark-") as directory:
+        out_link = Path(directory) / "activation-package"
+        build_sample = timed_command("activation-build", 1, build_command(target, out_link))
+        samples.append(build_sample)
+        if build_sample.exit_code != 0:
+            return samples
+
+        activation_program = out_link / "activate"
+        if not activation_program.is_file():
+            print(
+                f"activation program not found at {activation_program}",
+                file=sys.stderr,
+            )
+            samples.append(Sample("activate", 1, 0.0, 66))
+            return samples
+
+        for iteration in range(1, repeat + 1):
+            samples.append(
+                timed_command("activate", iteration, [str(activation_program)])
+            )
+            if samples[-1].exit_code != 0:
+                break
+    return samples
+
+
+def summarize(samples: Sequence[Sample]) -> dict[str, Any]:
+    grouped: dict[str, list[float]] = {}
+    for sample in samples:
+        if sample.exit_code == 0:
+            grouped.setdefault(sample.phase, []).append(sample.elapsed_seconds)
+
+    return {
+        phase: {
+            "count": len(values),
+            "median_seconds": round(statistics.median(values), 6),
+            "min_seconds": round(min(values), 6),
+            "max_seconds": round(max(values), 6),
+        }
+        for phase, values in grouped.items()
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Benchmark Dubnium Nix build and activation phases",
+    )
+    parser.add_argument(
+        "phase",
+        choices=("plan", "build", "activate", "suite"),
+        help="phase to benchmark; activation is explicit and may change user state",
+    )
+    parser.add_argument(
+        "--target",
+        default=DEFAULT_TARGET,
+        help=f"flake target (default: {DEFAULT_TARGET})",
+    )
+    parser.add_argument(
+        "--repeat",
+        type=int,
+        default=3,
+        help="number of build/activation samples (default: 3)",
+    )
+    parser.add_argument(
+        "--json",
+        dest="json_path",
+        type=Path,
+        help="write the complete result as JSON",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.repeat < 1 or args.repeat > 20:
+        print("--repeat must be between 1 and 20", file=sys.stderr)
+        return 64
+
+    samples: list[Sample] = []
+    if args.phase in ("plan", "suite"):
+        samples.extend(benchmark_plan(args.target))
+    if args.phase in ("build", "suite") and all(s.exit_code == 0 for s in samples):
+        samples.extend(benchmark_build(args.target, args.repeat))
+    if args.phase == "activate":
+        samples.extend(benchmark_activation(args.target, args.repeat))
+
+    result = {
+        "schema_version": 1,
+        "target": args.target,
+        "requested_phase": args.phase,
+        "repeat": args.repeat,
+        "timestamp_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "host": {
+            "hostname": platform.node(),
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+            "cpu_count": os.cpu_count(),
+        },
+        "repository": repository_metadata(),
+        "nix": nix_metadata(),
+        "samples": [asdict(sample) for sample in samples],
+        "summary": summarize(samples),
+    }
+
+    print(json.dumps(result, indent=2, sort_keys=True))
+    if args.json_path is not None:
+        args.json_path.parent.mkdir(parents=True, exist_ok=True)
+        args.json_path.write_text(
+            json.dumps(result, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    return 0 if samples and all(sample.exit_code == 0 for sample in samples) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_benchmark_nix_build.py
+++ b/tests/test_benchmark_nix_build.py
@@ -58,6 +58,7 @@ class BenchmarkNixBuildTests(unittest.TestCase):
                     1,
                     ["fake"],
                     cwd=ROOT,
+                    capture_stdout=True,
                 )
         self.assertEqual(stdout.getvalue(), "")
         self.assertEqual(measurement.stdout, "child noise\n")

--- a/tests/test_benchmark_nix_build.py
+++ b/tests/test_benchmark_nix_build.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+from types import ModuleType
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "benchmark-nix-build.py"
+
+
+def load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("benchmark_nix_build", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load {SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+benchmark = load_module()
+
+
+class BenchmarkNixBuildTests(unittest.TestCase):
+    def test_evaluation_and_realization_are_separate_commands(self) -> None:
+        target = '.#homeConfigurations."ryjen@dubnium".activationPackage'
+        drv = "/nix/store/example.drv"
+        self.assertEqual(
+            benchmark.evaluation_command(target),
+            ["nix", "eval", "--raw", f"{target}.drvPath"],
+        )
+        self.assertEqual(
+            benchmark.realization_command(drv),
+            ["nix-store", "--realise", drv],
+        )
+        self.assertNotIn(target, benchmark.realization_command(drv))
+
+    def test_timed_command_keeps_child_stdout_out_of_json_stream(self) -> None:
+        completed = subprocess.CompletedProcess(
+            args=["fake"],
+            returncode=0,
+            stdout="child noise\n",
+        )
+        stdout = io.StringIO()
+        with mock.patch.object(benchmark, "run", return_value=completed):
+            with redirect_stdout(stdout):
+                measurement = benchmark.timed_command(
+                    "test",
+                    1,
+                    ["fake"],
+                    cwd=ROOT,
+                )
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertEqual(measurement.stdout, "child noise\n")
+
+    def test_substituters_are_fingerprinted_not_exposed(self) -> None:
+        raw = {
+            "max-jobs": {"value": 4},
+            "cores": {"value": 3},
+            "max-substitution-jobs": {"value": 16},
+            "substituters": {
+                "value": (
+                    "https://user:secret@cache.internal.example/path?token=bad "
+                    "https://cache.nixos.org"
+                )
+            },
+        }
+        with mock.patch.object(benchmark, "read_nix_config", return_value=raw):
+            with mock.patch.object(benchmark, "capture", return_value="nix 2.test"):
+                metadata = benchmark.nix_metadata(ROOT)
+        encoded = json.dumps(metadata)
+        self.assertNotIn("cache.internal.example", encoded)
+        self.assertNotIn("secret", encoded)
+        self.assertEqual(metadata["settings"]["substituters"]["count"], 2)
+        self.assertEqual(len(metadata["settings"]["substituters"]["sha256"]), 64)
+
+    def test_nix_metadata_unavailable_is_explicit(self) -> None:
+        with mock.patch.object(benchmark, "read_nix_config", return_value=None):
+            with mock.patch.object(benchmark, "capture", return_value=None):
+                metadata = benchmark.nix_metadata(ROOT)
+        self.assertIsNone(metadata["version"])
+        self.assertFalse(metadata["settings"]["available"])
+        self.assertIsNone(metadata["settings"]["max-jobs"])
+
+    def test_main_propagates_benchmark_failure(self) -> None:
+        samples = [benchmark.Sample("evaluate", 1, 0.1, 1)]
+        stdout = io.StringIO()
+        with mock.patch.object(benchmark, "benchmark_build", return_value=samples):
+            with mock.patch.object(
+                benchmark,
+                "repository_metadata",
+                return_value={"available": True, "revision": "abc", "dirty": False},
+            ):
+                with mock.patch.object(
+                    benchmark,
+                    "nix_metadata",
+                    return_value={"version": "nix", "settings": {}},
+                ):
+                    with redirect_stdout(stdout):
+                        exit_code = benchmark.main(["build", "--repeat", "1"])
+        self.assertEqual(exit_code, 1)
+        self.assertEqual(json.loads(stdout.getvalue())["samples"][0]["exit_code"], 1)
+
+    def test_main_reports_output_file_failure_with_parseable_stdout(self) -> None:
+        samples = [benchmark.Sample("evaluate", 1, 0.1, 0)]
+        stdout = io.StringIO()
+        with mock.patch.object(benchmark, "benchmark_build", return_value=samples):
+            with mock.patch.object(
+                benchmark,
+                "repository_metadata",
+                return_value={"available": True, "revision": "abc", "dirty": False},
+            ):
+                with mock.patch.object(
+                    benchmark,
+                    "nix_metadata",
+                    return_value={"version": "nix", "settings": {}},
+                ):
+                    with mock.patch.object(
+                        benchmark,
+                        "atomic_write_json",
+                        side_effect=OSError("denied"),
+                    ):
+                        with redirect_stdout(stdout):
+                            exit_code = benchmark.main(
+                                ["build", "--repeat", "1", "--json", "result.json"]
+                            )
+        self.assertEqual(exit_code, 73)
+        self.assertEqual(json.loads(stdout.getvalue())["schema_version"], 2)
+
+    def test_repository_metadata_unavailable_is_not_reported_clean(self) -> None:
+        with mock.patch.object(
+            benchmark,
+            "capture_status",
+            side_effect=[(False, None), (False, None)],
+        ):
+            metadata = benchmark.repository_metadata(ROOT)
+        self.assertEqual(
+            metadata,
+            {"available": False, "revision": None, "dirty": None},
+        )
+
+    def test_repository_status_failure_does_not_claim_clean_tree(self) -> None:
+        with mock.patch.object(
+            benchmark,
+            "capture_status",
+            side_effect=[(True, "abc123"), (False, None)],
+        ):
+            metadata = benchmark.repository_metadata(ROOT)
+        self.assertFalse(metadata["available"])
+        self.assertEqual(metadata["revision"], "abc123")
+        self.assertIsNone(metadata["dirty"])
+
+    def test_activation_defaults_to_one_but_explicit_repeat_is_honored(self) -> None:
+        args = benchmark.parse_args(["activate"])
+        self.assertEqual(benchmark.effective_repeat(args), 1)
+        args = benchmark.parse_args(["activate", "--repeat", "4"])
+        self.assertEqual(benchmark.effective_repeat(args), 4)
+        args = benchmark.parse_args(["build"])
+        self.assertEqual(benchmark.effective_repeat(args), 3)
+
+    def test_external_target_is_rejected_to_preserve_provenance(self) -> None:
+        args = benchmark.parse_args(["build", "--target", "github:owner/repo#package"])
+        repeat = benchmark.effective_repeat(args)
+        self.assertIsNotNone(benchmark.validate_args(args, repeat))
+
+    def test_repeat_bounds_fail_closed(self) -> None:
+        args = benchmark.parse_args(["build", "--repeat", "0"])
+        self.assertIn("between", benchmark.validate_args(args, 0))
+        args = benchmark.parse_args(["build", "--repeat", "21"])
+        self.assertIn("between", benchmark.validate_args(args, 21))
+
+    def test_missing_activation_program_returns_failure_sample(self) -> None:
+        evaluate_sample = benchmark.Sample("evaluate", 1, 0.1, 0)
+        realize_sample = benchmark.Sample("realize", 1, 0.2, 0)
+        with tempfile.TemporaryDirectory() as directory:
+            output = str(Path(directory) / "missing-output")
+            with mock.patch.object(
+                benchmark,
+                "evaluate_target",
+                return_value=(evaluate_sample, "/nix/store/example.drv"),
+            ):
+                with mock.patch.object(
+                    benchmark,
+                    "realize_drv",
+                    return_value=(realize_sample, [output]),
+                ):
+                    samples = benchmark.benchmark_activation(
+                        benchmark.DEFAULT_TARGET,
+                        1,
+                        cwd=ROOT,
+                    )
+        self.assertEqual(samples[-1].phase, "activate")
+        self.assertEqual(samples[-1].exit_code, 66)
+
+    def test_atomic_json_write_failure_is_reported_without_corrupting_stdout(self) -> None:
+        result = {"ok": True}
+        payload = json.dumps(result) + "\n"
+        with tempfile.TemporaryDirectory() as directory:
+            parent_as_file = Path(directory) / "not-a-directory"
+            parent_as_file.write_text("x", encoding="utf-8")
+            with self.assertRaises(OSError):
+                benchmark.atomic_write_json(parent_as_file / "result.json", payload)
+
+    def test_main_emits_parseable_json_without_hostname_by_default(self) -> None:
+        samples = [benchmark.Sample("evaluate", 1, 0.1, 0)]
+        stdout = io.StringIO()
+        with mock.patch.object(benchmark, "benchmark_build", return_value=samples):
+            with mock.patch.object(
+                benchmark,
+                "repository_metadata",
+                return_value={"available": True, "revision": "abc", "dirty": False},
+            ):
+                with mock.patch.object(
+                    benchmark,
+                    "nix_metadata",
+                    return_value={"version": "nix", "settings": {}},
+                ):
+                    with redirect_stdout(stdout):
+                        exit_code = benchmark.main(["build", "--repeat", "1"])
+        self.assertEqual(exit_code, 0)
+        parsed = json.loads(stdout.getvalue())
+        self.assertNotIn("hostname", parsed["host"])
+        self.assertEqual(parsed["schema_version"], 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Implements the P0 benchmark harness from #125 under the local build-performance plan in #124.

The repository now exposes:

```bash
nix run .#benchmark-dubnium -- plan --repeat 3
nix run .#benchmark-dubnium -- build --repeat 3 --json result.json
nix run .#benchmark-dubnium -- suite --repeat 3
nix run .#benchmark-dubnium -- activate
```

## Behavior

- measures Nix evaluation and derivation realization as distinct phases;
- measures dry-run planning separately;
- makes activation explicit and defaults it to one run;
- reserves stdout for one machine-readable JSON document;
- routes child diagnostics to stderr without retaining unbounded activation output;
- records individual samples and median/minimum/maximum summaries;
- binds commands and Git provenance to a tracked local `--flake-dir`;
- rejects external flake targets that could produce misleading provenance;
- reports unavailable Git/Nix metadata explicitly rather than claiming a clean state;
- omits literal hostnames by default;
- fingerprints substituter configuration without exposing URLs or credentials;
- writes optional result files atomically;
- performs no garbage collection, store deletion, cache clearing, or implicit activation.

## Tests

Adds a repository-owned Nix check running 14 focused unit tests covering:

- evaluation/realization command separation;
- clean JSON stdout despite noisy child commands;
- failure propagation;
- activation defaults and repeat bounds;
- unavailable Git and Nix metadata;
- provenance restrictions;
- hostname and substituter redaction;
- missing activation programs;
- atomic output-file failures.

A fake-Nix end-to-end validation also confirmed ordered `evaluate`/`realize` samples and parseable, sanitized JSON.

## Documentation

Adds `docs/nix-build-performance.md` with the command contract, output handling, safety boundary, and baseline procedure.

## Remaining follow-up

After merge, run the first real baseline on Dubnium and attach the JSON evidence to #124. Scheduler tuning in #126 and invalidation/activation analysis in #127 remain blocked on that evidence.

Closes #125 when the Dubnium baseline is attached.