### PR TITLE
perf: isolate Home Manager feature evaluation costs

### DIFF
--- a/docs/home-feature-evaluation.md
+++ b/docs/home-feature-evaluation.md
@@ -1,0 +1,59 @@
+# Controlled Home Manager feature evaluation
+
+Use this diagnostic after the tracked-profile comparison shows a material
+workstation or host-specific evaluation delta.
+
+```bash
+cd ~/.local/src/dotfiles
+
+python3 scripts/benchmark-home-feature-evaluation.py \
+  --repeat 3 \
+  --output benchmark-results/home-feature-evaluation.json \
+  | jq .variants
+```
+
+The default comparison evaluates an identical graphical Home Manager baseline
+and then enables these feature sets independently:
+
+- meeting support;
+- Hermes;
+- Antigravity;
+- Headroom proxy;
+- OpenWork;
+- ops-cadence;
+- the workstation combination;
+- the Dubnium combination.
+
+Each result includes individual samples, median/minimum/maximum times, and the
+delta from `graphical-base`.
+
+## Safety boundary
+
+The profiler:
+
+- evaluates only `activationPackage.drvPath`;
+- never realizes an output;
+- never activates a Home Manager generation;
+- never clears caches or garbage-collects the store;
+- creates temporary Nix expressions outside the repository;
+- leaves production profiles unchanged.
+
+The generated expression uses `builtins.getFlake` with an explicit local checkout
+and therefore runs `nix eval --impure`. This impurity is limited to selecting the
+local tracked checkout for diagnostic evaluation. The result records the Git
+revision and dirty-tree state so measurements can be attributed correctly.
+
+Run from a clean checkout with unrelated CPU- and disk-heavy work idle. Attach
+the JSON result to issues #132, #130, and #127.
+
+## Focused comparison
+
+A subset can be selected, but include `graphical-base` so deltas remain defined:
+
+```bash
+python3 scripts/benchmark-home-feature-evaluation.py \
+  --variant graphical-base \
+  --variant meeting \
+  --variant hermes \
+  --repeat 5
+```

--- a/scripts/benchmark-home-feature-evaluation.py
+++ b/scripts/benchmark-home-feature-evaluation.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Measure isolated Home Manager feature evaluation cost.
+
+The profiler creates temporary Nix expressions that instantiate the tracked
+Home Manager module catalog from the current flake and enable one controlled
+feature set at a time. It evaluates only activation-package drvPath values; it
+never realizes outputs, activates a generation, clears caches, or mutates the
+Nix store.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Sequence
+
+MAX_REPEAT = 20
+DEFAULT_VARIANTS = (
+    "graphical-base",
+    "meeting",
+    "hermes",
+    "antigravity",
+    "headroom",
+    "openwork",
+    "ops-cadence",
+    "workstation-combined",
+    "dubnium-combined",
+)
+
+VARIANT_CONFIG = {
+    "graphical-base": "",
+    "meeting": "dotfiles.meeting.enable = true;",
+    "hermes": "dotfiles.agents.hermes.enable = true;",
+    "antigravity": "dotfiles.agents.antigravity.enable = true;",
+    "headroom": "dotfiles.headroom.proxy.enable = true;",
+    "openwork": "dotfiles.openwork.enable = true;",
+    "ops-cadence": "dotfiles.opsCadence.enable = true;",
+    "workstation-combined": """
+      dotfiles.profiles.workstation.enable = true;
+      dotfiles.meeting.enable = true;
+      dotfiles.agents.hermes.enable = true;
+      dotfiles.agents.antigravity.enable = true;
+      dotfiles.headroom.proxy.enable = true;
+    """,
+    "dubnium-combined": """
+      dotfiles.profiles.workstation.enable = true;
+      dotfiles.meeting.enable = true;
+      dotfiles.agents.hermes.enable = true;
+      dotfiles.agents.antigravity.enable = true;
+      dotfiles.headroom.proxy.enable = true;
+      dotfiles.profiles.browser.enable = true;
+      dotfiles.profiles.office.enable = true;
+      dotfiles.openwork.enable = true;
+      dotfiles.opsCadence.enable = true;
+      dotfiles.music.enable = true;
+      dotfiles.music.musicDirectory = \"/mnt/isotope/Music\";
+    """,
+}
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compare isolated Home Manager feature evaluation cost",
+    )
+    parser.add_argument("--flake-dir", type=Path, default=Path("."))
+    parser.add_argument("--repeat", type=int, default=3)
+    parser.add_argument("--variant", action="append", dest="variants")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("benchmark-results/home-feature-evaluation.json"),
+    )
+    return parser.parse_args(argv)
+
+
+def validate(args: argparse.Namespace) -> str | None:
+    if not args.flake_dir.is_dir():
+        return "--flake-dir must be an existing directory"
+    if args.repeat < 1 or args.repeat > MAX_REPEAT:
+        return f"--repeat must be between 1 and {MAX_REPEAT}"
+    for variant in args.variants or DEFAULT_VARIANTS:
+        if variant not in VARIANT_CONFIG:
+            return f"unknown variant: {variant}"
+    return None
+
+
+def nix_expression(flake_dir: Path, config_text: str) -> str:
+    escaped = json.dumps(str(flake_dir))
+    return f'''let
+  flake = builtins.getFlake {escaped};
+  system = "x86_64-linux";
+  username = "ryjen";
+  pkgs = import flake.inputs.nixpkgs {{
+    inherit system;
+    config.allowUnfree = true;
+  }};
+  configuration = flake.inputs.home-manager.lib.homeManagerConfiguration {{
+    inherit pkgs;
+    extraSpecialArgs = {{
+      inherit username;
+      self = flake;
+      hermes-agent = flake.inputs.hermes-agent;
+      antigravity-nix = flake.inputs.antigravity-nix;
+      ops-cadence = flake.inputs.ops-cadence;
+      git-autocommit = flake.inputs.git-autocommit;
+    }};
+    modules = [
+      ({escaped} + "/home/ryjen/layers/graphical.nix")
+      ({escaped} + "/home/ryjen/profiles/graphical.nix")
+      flake.inputs.sops-nix.homeManagerModules.sops
+      ({{ ... }}: {{
+        home.username = username;
+        home.homeDirectory = "/home/${{username}}";
+        home.stateVersion = "25.05";
+        programs.home-manager.enable = true;
+        dotfiles.host.userSystemd.enable = true;
+        {config_text}
+      }})
+    ];
+  }};
+in configuration.activationPackage.drvPath
+'''
+
+
+def evaluate(expression_path: Path, cwd: Path) -> tuple[float, int]:
+    started = time.perf_counter()
+    completed = subprocess.run(
+        ["nix", "eval", "--impure", "--raw", "--file", str(expression_path)],
+        cwd=cwd,
+        stdout=subprocess.DEVNULL,
+        stderr=None,
+        check=False,
+        text=True,
+    )
+    return round(time.perf_counter() - started, 6), completed.returncode
+
+
+def git_metadata(cwd: Path) -> dict[str, Any]:
+    def capture(*command: str) -> str | None:
+        completed = subprocess.run(
+            command,
+            cwd=cwd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            check=False,
+        )
+        return completed.stdout.strip() if completed.returncode == 0 else None
+
+    revision = capture("git", "rev-parse", "HEAD")
+    status = capture("git", "status", "--porcelain")
+    return {
+        "available": revision is not None and status is not None,
+        "revision": revision,
+        "dirty": bool(status) if status is not None else None,
+    }
+
+
+def atomic_write(path: Path, payload: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as temporary:
+        temporary_path = Path(temporary.name)
+        temporary.write(payload)
+    temporary_path.replace(path)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    error = validate(args)
+    if error:
+        print(error, file=sys.stderr)
+        return 64
+
+    flake_dir = args.flake_dir.resolve()
+    variants = tuple(dict.fromkeys(args.variants or DEFAULT_VARIANTS))
+    results: list[dict[str, Any]] = []
+
+    with tempfile.TemporaryDirectory(prefix="dotfiles-feature-eval-") as directory:
+        temporary_dir = Path(directory)
+        for variant in variants:
+            expression_path = temporary_dir / f"{variant}.nix"
+            expression_path.write_text(
+                nix_expression(flake_dir, VARIANT_CONFIG[variant]),
+                encoding="utf-8",
+            )
+            samples: list[float] = []
+            for iteration in range(1, args.repeat + 1):
+                elapsed, exit_code = evaluate(expression_path, flake_dir)
+                if exit_code != 0:
+                    print(
+                        f"evaluation failed for {variant} iteration {iteration}",
+                        file=sys.stderr,
+                    )
+                    return 1
+                samples.append(elapsed)
+            results.append(
+                {
+                    "variant": variant,
+                    "count": len(samples),
+                    "samples_seconds": samples,
+                    "median_seconds": round(statistics.median(samples), 6),
+                    "min_seconds": round(min(samples), 6),
+                    "max_seconds": round(max(samples), 6),
+                }
+            )
+
+    ranked = sorted(results, key=lambda item: item["median_seconds"])
+    baseline = next(
+        item["median_seconds"] for item in ranked if item["variant"] == "graphical-base"
+    )
+    for item in ranked:
+        item["delta_from_graphical_base_seconds"] = round(
+            item["median_seconds"] - baseline,
+            6,
+        )
+
+    result = {
+        "schema_version": 1,
+        "kind": "home-feature-evaluation-comparison",
+        "repeat": args.repeat,
+        "repository": git_metadata(flake_dir),
+        "timestamp_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "variants": ranked,
+        "notes": {
+            "evaluation_only": True,
+            "uses_impure_local_flake_reference": True,
+            "realizes_outputs": False,
+            "activates_generation": False,
+        },
+    }
+    payload = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    output = args.output if args.output.is_absolute() else flake_dir / args.output
+    try:
+        atomic_write(output, payload)
+    except OSError as write_error:
+        print(f"unable to write result: {write_error}", file=sys.stderr)
+        return 73
+    sys.stdout.write(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark-home-feature-evaluation.py
+++ b/scripts/benchmark-home-feature-evaluation.py
@@ -1,12 +1,5 @@
 #!/usr/bin/env python3
-"""Measure isolated Home Manager feature evaluation cost.
-
-The profiler creates temporary Nix expressions that instantiate the tracked
-Home Manager module catalog from the current flake and enable one controlled
-feature set at a time. It evaluates only activation-package drvPath values; it
-never realizes outputs, activates a generation, clears caches, or mutates the
-Nix store.
-"""
+"""Compare isolated Home Manager feature evaluation cost."""
 
 from __future__ import annotations
 
@@ -21,19 +14,7 @@ from pathlib import Path
 from typing import Any, Sequence
 
 MAX_REPEAT = 20
-DEFAULT_VARIANTS = (
-    "graphical-base",
-    "meeting",
-    "hermes",
-    "antigravity",
-    "headroom",
-    "openwork",
-    "ops-cadence",
-    "workstation-combined",
-    "dubnium-combined",
-)
-
-VARIANT_CONFIG = {
+VARIANTS = {
     "graphical-base": "",
     "meeting": "dotfiles.meeting.enable = true;",
     "hermes": "dotfiles.agents.hermes.enable = true;",
@@ -62,11 +43,12 @@ VARIANT_CONFIG = {
       dotfiles.music.musicDirectory = \"/mnt/isotope/Music\";
     """,
 }
+DEFAULT_VARIANTS = tuple(VARIANTS)
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Compare isolated Home Manager feature evaluation cost",
+        description="Compare isolated Home Manager feature evaluation cost"
     )
     parser.add_argument("--flake-dir", type=Path, default=Path("."))
     parser.add_argument("--repeat", type=int, default=3)
@@ -82,18 +64,17 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 def validate(args: argparse.Namespace) -> str | None:
     if not args.flake_dir.is_dir():
         return "--flake-dir must be an existing directory"
-    if args.repeat < 1 or args.repeat > MAX_REPEAT:
+    if not 1 <= args.repeat <= MAX_REPEAT:
         return f"--repeat must be between 1 and {MAX_REPEAT}"
-    for variant in args.variants or DEFAULT_VARIANTS:
-        if variant not in VARIANT_CONFIG:
-            return f"unknown variant: {variant}"
-    return None
+    unknown = [name for name in args.variants or DEFAULT_VARIANTS if name not in VARIANTS]
+    return f"unknown variant: {unknown[0]}" if unknown else None
 
 
 def nix_expression(flake_dir: Path, config_text: str) -> str:
-    escaped = json.dumps(str(flake_dir))
+    root = json.dumps(str(flake_dir))
     return f'''let
-  flake = builtins.getFlake {escaped};
+  root = builtins.toPath {root};
+  flake = builtins.getFlake (toString root);
   system = "x86_64-linux";
   username = "ryjen";
   pkgs = import flake.inputs.nixpkgs {{
@@ -111,8 +92,8 @@ def nix_expression(flake_dir: Path, config_text: str) -> str:
       git-autocommit = flake.inputs.git-autocommit;
     }};
     modules = [
-      ({escaped} + "/home/ryjen/layers/graphical.nix")
-      ({escaped} + "/home/ryjen/profiles/graphical.nix")
+      (root + "/home/ryjen/layers/graphical.nix")
+      (root + "/home/ryjen/profiles/graphical.nix")
       flake.inputs.sops-nix.homeManagerModules.sops
       ({{ ... }}: {{
         home.username = username;
@@ -134,16 +115,14 @@ def evaluate(expression_path: Path, cwd: Path) -> tuple[float, int]:
         ["nix", "eval", "--impure", "--raw", "--file", str(expression_path)],
         cwd=cwd,
         stdout=subprocess.DEVNULL,
-        stderr=None,
         check=False,
-        text=True,
     )
     return round(time.perf_counter() - started, 6), completed.returncode
 
 
 def git_metadata(cwd: Path) -> dict[str, Any]:
     def capture(*command: str) -> str | None:
-        completed = subprocess.run(
+        result = subprocess.run(
             command,
             cwd=cwd,
             stdout=subprocess.PIPE,
@@ -151,7 +130,7 @@ def git_metadata(cwd: Path) -> dict[str, Any]:
             text=True,
             check=False,
         )
-        return completed.stdout.strip() if completed.returncode == 0 else None
+        return result.stdout.strip() if result.returncode == 0 else None
 
     revision = capture("git", "rev-parse", "HEAD")
     status = capture("git", "status", "--porcelain")
@@ -164,17 +143,23 @@ def git_metadata(cwd: Path) -> dict[str, Any]:
 
 def atomic_write(path: Path, payload: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.NamedTemporaryFile(
-        mode="w",
-        encoding="utf-8",
-        dir=path.parent,
-        prefix=f".{path.name}.",
-        suffix=".tmp",
-        delete=False,
-    ) as temporary:
-        temporary_path = Path(temporary.name)
-        temporary.write(payload)
-    temporary_path.replace(path)
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as temporary:
+            temporary_path = Path(temporary.name)
+            temporary.write(payload)
+        temporary_path.replace(path)
+    except OSError:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+        raise
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -185,20 +170,19 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 64
 
     flake_dir = args.flake_dir.resolve()
-    variants = tuple(dict.fromkeys(args.variants or DEFAULT_VARIANTS))
+    selected = tuple(dict.fromkeys(args.variants or DEFAULT_VARIANTS))
     results: list[dict[str, Any]] = []
 
     with tempfile.TemporaryDirectory(prefix="dotfiles-feature-eval-") as directory:
         temporary_dir = Path(directory)
-        for variant in variants:
-            expression_path = temporary_dir / f"{variant}.nix"
-            expression_path.write_text(
-                nix_expression(flake_dir, VARIANT_CONFIG[variant]),
-                encoding="utf-8",
+        for variant in selected:
+            expression = temporary_dir / f"{variant}.nix"
+            expression.write_text(
+                nix_expression(flake_dir, VARIANTS[variant]), encoding="utf-8"
             )
             samples: list[float] = []
             for iteration in range(1, args.repeat + 1):
-                elapsed, exit_code = evaluate(expression_path, flake_dir)
+                elapsed, exit_code = evaluate(expression, flake_dir)
                 if exit_code != 0:
                     print(
                         f"evaluation failed for {variant} iteration {iteration}",
@@ -219,12 +203,13 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     ranked = sorted(results, key=lambda item: item["median_seconds"])
     baseline = next(
-        item["median_seconds"] for item in ranked if item["variant"] == "graphical-base"
+        item["median_seconds"]
+        for item in ranked
+        if item["variant"] == "graphical-base"
     )
     for item in ranked:
         item["delta_from_graphical_base_seconds"] = round(
-            item["median_seconds"] - baseline,
-            6,
+            item["median_seconds"] - baseline, 6
         )
 
     result = {


### PR DESCRIPTION
## Summary

Implements the controlled feature-evaluation slice from #132 under #130 and #127.

Adds an audit-only profiler that instantiates the tracked graphical Home Manager module catalog and enables expensive workstation features independently.

## Variants

- `graphical-base`
- `meeting`
- `hermes`
- `antigravity`
- `headroom`
- `openwork`
- `ops-cadence`
- `workstation-combined`
- `dubnium-combined`

## Behavior

- evaluates only `activationPackage.drvPath`;
- records three samples per variant by default;
- reports median/minimum/maximum and delta from `graphical-base`;
- records Git revision and dirty-tree state;
- writes JSON atomically;
- rejects unknown variants and invalid repeat counts;
- performs no realization, activation, GC, or cache clearing;
- leaves production profiles unchanged.

## Diagnostic impurity

The generated expression uses `builtins.getFlake` for the explicit local checkout and therefore calls `nix eval --impure`. This is limited to selecting the local tracked checkout. The command records repository provenance so results remain attributable.

## Usage

```bash
python3 scripts/benchmark-home-feature-evaluation.py \
  --repeat 3 \
  --output benchmark-results/home-feature-evaluation.json \
  | jq .variants
```

## Follow-up

Run on Dubnium and attach the JSON evidence to #132, #130, and #127. The largest isolated delta should become the next implementation target.

Closes no issue until the real Dubnium result is recorded.