### PR TITLE
perf: remove Android activation-time download

### DIFF
--- a/modules/home/android.nix
+++ b/modules/home/android.nix
@@ -13,29 +13,9 @@
       android-tools
     ];
 
-    home.activation.installAndroidAgentCli = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-      target="$HOME/.local/bin/android"
-
-      if [ ! -x "$target" ]; then
-        mkdir -p "$(dirname "$target")"
-        tmp="$(${pkgs.coreutils}/bin/mktemp)"
-        trap '${pkgs.coreutils}/bin/rm -f "$tmp"' EXIT
-
-        if ${pkgs.curl}/bin/curl \
-          --fail \
-          --silent \
-          --show-error \
-          --location \
-          --connect-timeout 15 \
-          --max-time 120 \
-          https://dl.google.com/android/cli/latest/linux_x86_64/android \
-          --output "$tmp"; then
-          ${pkgs.coreutils}/bin/install -m 0755 "$tmp" "$target"
-        else
-          echo "warning: Android CLI download unavailable; install it from https://developer.android.com/tools/agents" >&2
-        fi
-      fi
-    '';
+    # Keep optional Android agent tooling out of Home Manager activation until
+    # it is available as a pinned, integrity-verified Nix package. Activation
+    # must not download mutable executables into the user's home directory.
 
     xdg.configFile."zsh/config.d/android".source = ../../files/home/.config/zsh/config.d/android;
 


### PR DESCRIPTION
## Summary

Removes the Android agent CLI network installer from normal Home Manager activation.

Closes #140.
Related: #127, #124.

## Root cause

`modules/home/android.nix` downloaded a mutable executable from `dl.google.com` into `~/.local/bin/android` during activation. The download was not hash- or signature-verified, bypassed the Nix store and generation rollback, and converted failures into warnings.

## Change

- remove the activation-time `curl` installer;
- retain declarative `android-studio` and `android-tools` packages;
- retain Android shell configuration and `droidctl`;
- document that any future managed Android agent CLI must be packaged through a pinned, integrity-verified Nix derivation.

## Impact

Normal Android profile activation no longer performs network access or installs unsigned mutable executables into the user home directory.

## Validation

CI should confirm Home Manager and NixOS evaluation/build contracts remain intact.