### PR TITLE
perf: make Variety activation idempotent

### DIFF
--- a/docs/nix-build-performance.md
+++ b/docs/nix-build-performance.md
@@ -4,6 +4,9 @@ The benchmark harness measures the tracked Dubnium Home Manager activation
 package without clearing caches, garbage-collecting the store, or activating a
 generation unless explicitly requested.
 
+Run the commands below from the repository root unless an explicit
+`--flake-dir` is supplied.
+
 ## Commands
 
 ```bash

--- a/flake.nix
+++ b/flake.nix
@@ -159,6 +159,24 @@
               touch "$out"
             '';
 
+        variety-activation-tests =
+          pkgs.runCommand "variety-activation-tests"
+            {
+              nativeBuildInputs = [
+                pkgs.bash
+                pkgs.coreutils
+                pkgs.diffutils
+                pkgs.gnugrep
+                pkgs.python3Packages.pytest
+              ];
+            }
+            ''
+              export PYTHONDONTWRITEBYTECODE=1
+              cd ${self}
+              pytest -q tests/test_variety_activation_contract.py
+              touch "$out"
+            '';
+
         flake-script-executables =
           pkgs.runCommand "flake-script-executables"
             {

--- a/modules/home/hypr.nix
+++ b/modules/home/hypr.nix
@@ -157,10 +157,9 @@ in
 
       if [ ! -f "$variety_config" ] || ! ${pkgs.diffutils}/bin/cmp -s "$tmp" "$variety_config"; then
         ${pkgs.coreutils}/bin/install -m 0600 "$tmp" "$variety_config"
-      else
-        ${pkgs.coreutils}/bin/rm -f "$tmp"
       fi
-      chmod 600 "$variety_config"
+      ${pkgs.coreutils}/bin/rm -f "$tmp"
+      ${pkgs.coreutils}/bin/chmod 600 "$variety_config"
     '';
   };
 }

--- a/modules/home/hypr.nix
+++ b/modules/home/hypr.nix
@@ -142,6 +142,8 @@ in
         "$variety_favorites"
 
       tmp="$(${pkgs.coreutils}/bin/mktemp)"
+      trap '${pkgs.coreutils}/bin/rm -f "$tmp"' EXIT
+
       if [ -f "$variety_config" ]; then
         ${pkgs.gnugrep}/bin/grep -Ev '^(download_folder|fetched_folder|favorites_folder|copyto_folder|wallpaper_auto_rotate|change_enabled|change_on_start)[[:space:]]*=' "$variety_config" > "$tmp" || true
       fi
@@ -157,9 +159,9 @@ in
 
       if [ ! -f "$variety_config" ] || ! ${pkgs.diffutils}/bin/cmp -s "$tmp" "$variety_config"; then
         ${pkgs.coreutils}/bin/install -m 0600 "$tmp" "$variety_config"
+      elif [ "$(${pkgs.coreutils}/bin/stat -c %a "$variety_config")" != "600" ]; then
+        ${pkgs.coreutils}/bin/chmod 600 "$variety_config"
       fi
-      ${pkgs.coreutils}/bin/rm -f "$tmp"
-      ${pkgs.coreutils}/bin/chmod 600 "$variety_config"
     '';
   };
 }

--- a/modules/home/hypr.nix
+++ b/modules/home/hypr.nix
@@ -141,27 +141,33 @@ in
         "$variety_fetched" \
         "$variety_favorites"
 
-      tmp="$(${pkgs.coreutils}/bin/mktemp)"
-      trap '${pkgs.coreutils}/bin/rm -f "$tmp"' EXIT
+      (
+        tmp="$(${pkgs.coreutils}/bin/mktemp)"
+        trap '${pkgs.coreutils}/bin/rm -f "$tmp"' EXIT
 
-      if [ -f "$variety_config" ]; then
-        ${pkgs.gnugrep}/bin/grep -Ev '^(download_folder|fetched_folder|favorites_folder|copyto_folder|wallpaper_auto_rotate|change_enabled|change_on_start)[[:space:]]*=' "$variety_config" > "$tmp" || true
-      fi
-      {
-        printf '%s\n' 'download_folder = ~/Pictures/wallpaper/variety/downloaded'
-        printf '%s\n' 'fetched_folder = ~/Pictures/wallpaper/variety/fetched'
-        printf '%s\n' 'favorites_folder = ~/Pictures/wallpaper/variety/favorites'
-        printf '%s\n' 'copyto_folder = ~/Pictures/wallpaper/variety/favorites'
-        printf '%s\n' 'wallpaper_auto_rotate = False'
-        printf '%s\n' 'change_enabled = False'
-        printf '%s\n' 'change_on_start = False'
-      } >> "$tmp"
+        if [ -f "$variety_config" ]; then
+          grep_status=0
+          ${pkgs.gnugrep}/bin/grep -Ev '^(download_folder|fetched_folder|favorites_folder|copyto_folder|wallpaper_auto_rotate|change_enabled|change_on_start)[[:space:]]*=' "$variety_config" > "$tmp" || grep_status=$?
+          if [ "$grep_status" -gt 1 ]; then
+            exit "$grep_status"
+          fi
+        fi
+        {
+          printf '%s\n' 'download_folder = ~/Pictures/wallpaper/variety/downloaded'
+          printf '%s\n' 'fetched_folder = ~/Pictures/wallpaper/variety/fetched'
+          printf '%s\n' 'favorites_folder = ~/Pictures/wallpaper/variety/favorites'
+          printf '%s\n' 'copyto_folder = ~/Pictures/wallpaper/variety/favorites'
+          printf '%s\n' 'wallpaper_auto_rotate = False'
+          printf '%s\n' 'change_enabled = False'
+          printf '%s\n' 'change_on_start = False'
+        } >> "$tmp"
 
-      if [ ! -f "$variety_config" ] || ! ${pkgs.diffutils}/bin/cmp -s "$tmp" "$variety_config"; then
-        ${pkgs.coreutils}/bin/install -m 0600 "$tmp" "$variety_config"
-      elif [ "$(${pkgs.coreutils}/bin/stat -c %a "$variety_config")" != "600" ]; then
-        ${pkgs.coreutils}/bin/chmod 600 "$variety_config"
-      fi
+        if [ ! -f "$variety_config" ] || ! ${pkgs.diffutils}/bin/cmp -s "$tmp" "$variety_config"; then
+          ${pkgs.coreutils}/bin/install -m 0600 "$tmp" "$variety_config"
+        elif [ "$(${pkgs.coreutils}/bin/stat -c %a "$variety_config")" != "600" ]; then
+          ${pkgs.coreutils}/bin/chmod 600 "$variety_config"
+        fi
+      )
     '';
   };
 }

--- a/modules/home/hypr.nix
+++ b/modules/home/hypr.nix
@@ -141,11 +141,10 @@ in
         "$variety_fetched" \
         "$variety_favorites"
 
-      touch "$variety_config"
-      chmod 600 "$variety_config"
-
       tmp="$(${pkgs.coreutils}/bin/mktemp)"
-      ${pkgs.gnugrep}/bin/grep -Ev '^(download_folder|fetched_folder|favorites_folder|copyto_folder|wallpaper_auto_rotate|change_enabled|change_on_start)[[:space:]]*=' "$variety_config" > "$tmp" || true
+      if [ -f "$variety_config" ]; then
+        ${pkgs.gnugrep}/bin/grep -Ev '^(download_folder|fetched_folder|favorites_folder|copyto_folder|wallpaper_auto_rotate|change_enabled|change_on_start)[[:space:]]*=' "$variety_config" > "$tmp" || true
+      fi
       {
         printf '%s\n' 'download_folder = ~/Pictures/wallpaper/variety/downloaded'
         printf '%s\n' 'fetched_folder = ~/Pictures/wallpaper/variety/fetched'
@@ -155,8 +154,12 @@ in
         printf '%s\n' 'change_enabled = False'
         printf '%s\n' 'change_on_start = False'
       } >> "$tmp"
-      cat "$tmp" > "$variety_config"
-      rm -f "$tmp"
+
+      if [ ! -f "$variety_config" ] || ! ${pkgs.diffutils}/bin/cmp -s "$tmp" "$variety_config"; then
+        ${pkgs.coreutils}/bin/install -m 0600 "$tmp" "$variety_config"
+      else
+        ${pkgs.coreutils}/bin/rm -f "$tmp"
+      fi
       chmod 600 "$variety_config"
     '';
   };

--- a/tests/test_variety_activation_contract.py
+++ b/tests/test_variety_activation_contract.py
@@ -24,7 +24,9 @@ MANAGED_LINES = [
 
 def _activation_script() -> str:
     content = HYPR_MODULE.read_text(encoding="utf-8")
-    body = content.split(ACTIVATION_START, maxsplit=1)[1].split("\n    '';", maxsplit=1)[0]
+    body = content.split(ACTIVATION_START, maxsplit=1)[1].split(
+        "\n    '';", maxsplit=1
+    )[0]
     script = textwrap.dedent(body)
     for nix_prefix in (
         "${pkgs.coreutils}/bin/",

--- a/tests/test_variety_activation_contract.py
+++ b/tests/test_variety_activation_contract.py
@@ -5,11 +5,13 @@ ROOT = Path(__file__).resolve().parents[1]
 HYPR_MODULE = ROOT / "modules" / "home" / "hypr.nix"
 
 
-def test_variety_activation_is_content_gated() -> None:
+def test_variety_activation_is_content_and_metadata_gated() -> None:
     content = HYPR_MODULE.read_text(encoding="utf-8")
 
     assert "${pkgs.diffutils}/bin/cmp -s" in content
     assert 'touch "$variety_config"' not in content
     assert 'cat "$tmp" > "$variety_config"' not in content
     assert '${pkgs.coreutils}/bin/install -m 0600 "$tmp" "$variety_config"' in content
-    assert '${pkgs.coreutils}/bin/rm -f "$tmp"' in content
+    assert "trap '${pkgs.coreutils}/bin/rm -f \"$tmp\"' EXIT" in content
+    assert '${pkgs.coreutils}/bin/stat -c %a "$variety_config"' in content
+    assert '[ "$(${pkgs.coreutils}/bin/stat -c %a "$variety_config")" != "600" ]' in content

--- a/tests/test_variety_activation_contract.py
+++ b/tests/test_variety_activation_contract.py
@@ -1,17 +1,144 @@
+import os
+import stat
+import subprocess
+import textwrap
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
 HYPR_MODULE = ROOT / "modules" / "home" / "hypr.nix"
+ACTIVATION_START = (
+    '    home.activation.configureVarietyWallpaperFolders = '
+    'lib.hm.dag.entryAfter [ "writeBoundary" ] \'\'\n'
+)
+MANAGED_LINES = [
+    "download_folder = ~/Pictures/wallpaper/variety/downloaded",
+    "fetched_folder = ~/Pictures/wallpaper/variety/fetched",
+    "favorites_folder = ~/Pictures/wallpaper/variety/favorites",
+    "copyto_folder = ~/Pictures/wallpaper/variety/favorites",
+    "wallpaper_auto_rotate = False",
+    "change_enabled = False",
+    "change_on_start = False",
+]
 
 
-def test_variety_activation_is_content_and_metadata_gated() -> None:
+def _activation_script() -> str:
     content = HYPR_MODULE.read_text(encoding="utf-8")
+    body = content.split(ACTIVATION_START, maxsplit=1)[1].split("\n    '';", maxsplit=1)[0]
+    script = textwrap.dedent(body)
+    for nix_prefix in (
+        "${pkgs.coreutils}/bin/",
+        "${pkgs.gnugrep}/bin/",
+        "${pkgs.diffutils}/bin/",
+    ):
+        script = script.replace(nix_prefix, "")
+    assert "${pkgs." not in script
+    return script
 
-    assert "${pkgs.diffutils}/bin/cmp -s" in content
-    assert 'touch "$variety_config"' not in content
-    assert 'cat "$tmp" > "$variety_config"' not in content
-    assert '${pkgs.coreutils}/bin/install -m 0600 "$tmp" "$variety_config"' in content
-    assert "trap '${pkgs.coreutils}/bin/rm -f \"$tmp\"' EXIT" in content
-    assert '${pkgs.coreutils}/bin/stat -c %a "$variety_config"' in content
-    assert '[ "$(${pkgs.coreutils}/bin/stat -c %a "$variety_config")" != "600" ]' in content
+
+def _run_activation(
+    home: Path,
+    *,
+    path: str | None = None,
+    suffix: str = "",
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["HOME"] = str(home)
+    if path is not None:
+        env["PATH"] = path
+    return subprocess.run(
+        [
+            "bash",
+            "-e",
+            "-u",
+            "-o",
+            "pipefail",
+            "-c",
+            f"{_activation_script()}\n{suffix}",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _config_path(home: Path) -> Path:
+    return home / ".config" / "variety" / "variety.conf"
+
+
+def test_noop_activation_preserves_content_and_mtime(tmp_path: Path) -> None:
+    config = _config_path(tmp_path)
+    config.parent.mkdir(parents=True)
+    expected = "unmanaged_setting = keep\n" + "\n".join(MANAGED_LINES) + "\n"
+    config.write_text(expected, encoding="utf-8")
+    config.chmod(0o600)
+    fixed_time_ns = 1_700_000_000_000_000_000
+    os.utime(config, ns=(fixed_time_ns, fixed_time_ns))
+
+    result = _run_activation(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert config.read_text(encoding="utf-8") == expected
+    assert config.stat().st_mtime_ns == fixed_time_ns
+    assert stat.S_IMODE(config.stat().st_mode) == 0o600
+
+
+def test_activation_preserves_unmanaged_settings_and_updates_managed_values(
+    tmp_path: Path,
+) -> None:
+    config = _config_path(tmp_path)
+    config.parent.mkdir(parents=True)
+    config.write_text(
+        "unmanaged_setting = keep\n"
+        "download_folder = /obsolete\n"
+        "change_enabled = True\n",
+        encoding="utf-8",
+    )
+    config.chmod(0o644)
+
+    result = _run_activation(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    actual = config.read_text(encoding="utf-8")
+    assert "unmanaged_setting = keep\n" in actual
+    assert "/obsolete" not in actual
+    assert "change_enabled = True" not in actual
+    for line in MANAGED_LINES:
+        assert actual.count(f"{line}\n") == 1
+    assert stat.S_IMODE(config.stat().st_mode) == 0o600
+
+
+def test_activation_propagates_grep_errors_without_replacing_config(
+    tmp_path: Path,
+) -> None:
+    config = _config_path(tmp_path)
+    config.parent.mkdir(parents=True)
+    original = "unmanaged_setting = keep\n"
+    config.write_text(original, encoding="utf-8")
+
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir()
+    fake_grep = fake_bin / "grep"
+    fake_grep.write_text("#!/bin/sh\nexit 2\n", encoding="utf-8")
+    fake_grep.chmod(0o755)
+
+    result = _run_activation(
+        tmp_path,
+        path=f"{fake_bin}{os.pathsep}{os.environ['PATH']}",
+    )
+
+    assert result.returncode == 2
+    assert config.read_text(encoding="utf-8") == original
+
+
+def test_activation_cleanup_trap_does_not_leak(tmp_path: Path) -> None:
+    leak_target = tmp_path / "trap-must-not-leak"
+
+    result = _run_activation(
+        tmp_path,
+        suffix=f'tmp="{leak_target}"\ntouch "$tmp"',
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert leak_target.exists()

--- a/tests/test_variety_activation_contract.py
+++ b/tests/test_variety_activation_contract.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HYPR_MODULE = ROOT / "modules" / "home" / "hypr.nix"
+
+
+def test_variety_activation_is_content_gated() -> None:
+    content = HYPR_MODULE.read_text(encoding="utf-8")
+
+    assert "${pkgs.diffutils}/bin/cmp -s" in content
+    assert 'touch "$variety_config"' not in content
+    assert 'cat "$tmp" > "$variety_config"' not in content
+    assert '${pkgs.coreutils}/bin/install -m 0600 "$tmp" "$variety_config"' in content
+    assert '${pkgs.coreutils}/bin/rm -f "$tmp"' in content

--- a/tests/test_variety_activation_contract.py
+++ b/tests/test_variety_activation_contract.py
@@ -75,12 +75,13 @@ def test_noop_activation_preserves_content_and_mtime(tmp_path: Path) -> None:
     config.chmod(0o600)
     fixed_time_ns = 1_700_000_000_000_000_000
     os.utime(config, ns=(fixed_time_ns, fixed_time_ns))
+    initial_mtime_ns = config.stat().st_mtime_ns
 
     result = _run_activation(tmp_path)
 
     assert result.returncode == 0, result.stderr
     assert config.read_text(encoding="utf-8") == expected
-    assert config.stat().st_mtime_ns == fixed_time_ns
+    assert config.stat().st_mtime_ns == initial_mtime_ns
     assert stat.S_IMODE(config.stat().st_mode) == 0o600
 
 


### PR DESCRIPTION
## Summary

Makes the Variety wallpaper activation hook content- and metadata-idempotent and documents the activation-performance contract.

Closes #143.
Related: #127, #124, #150, #151.

## Change

- stop touching `variety.conf` before comparison;
- preserve unmanaged settings while regenerating the managed keys;
- compare the candidate file with the live configuration using `cmp`;
- replace the live file only when content differs;
- avoid permission writes when mode is already `0600`;
- scope temporary-file cleanup to a subshell so the `EXIT` trap cannot leak into later activation hooks;
- propagate real `grep` failures instead of treating every non-match/error as success;
- add behavioral tests for no-op mtime, unmanaged-setting preservation, error propagation, and trap isolation;
- expose those tests as the `variety-activation-tests` flake check;
- update `docs/nix-build-performance.md` with activation safety, execution context, test commands, and audit ownership;
- integrate current `main` without overlapping conflicts.

## Impact

A no-op Home Manager activation no longer rewrites `~/.config/variety/variety.conf` or changes its modification time solely because the activation hook ran. Read failures cannot silently replace the user configuration.

The public repository documentation now records the general contract for deterministic, network-free, change-gated activation work without exposing host-specific information.

## Validation

- local behavioral test run on the implementation head: 4 passed;
- the implementation head passed the user option catalog and Nix CI, including `repository-check (variety-activation-tests)`;
- current `main` was integrated without overlapping changes;
- final documentation-only update and complete diff were reviewed with no unresolved threads or blockers.

## Merge

Squash-merged as `3144657e6ea398a8511925f85ef8de2fc228d2e6`.