### PR TITLE
Harden user credentials and Podman trust defaults

### DIFF
--- a/home/ryjen/user.example.nix
+++ b/home/ryjen/user.example.nix
@@ -31,6 +31,14 @@
   # dotfiles.pip.prefix = "${config.home.homeDirectory}/.local/share/pip";
   # dotfiles.pip.globalPackagesFile = ".config/pip/global-packages.txt";
 
+  # Rootless Podman remains available without exposing its control socket.
+  # Unsigned compatibility exceptions must be fully qualified and narrowly scoped.
+  # dotfiles.podman.apiSocket.enable = false;
+  # dotfiles.podman.allowedUnsignedRegistries = [
+  #   "docker.io"
+  #   "ghcr.io"
+  # ];
+
   # Bitwarden clients. The Dubnium workstation profile enables both by default;
   # use these explicit selections when maintaining a complete local config.
   # dotfiles.bitwarden.cli.enable = true;

--- a/modules/home/common.nix
+++ b/modules/home/common.nix
@@ -4,42 +4,67 @@
   config,
   ...
 }:
+let
+  unsignedRegistryPolicy = lib.genAttrs config.dotfiles.podman.allowedUnsignedRegistries (_: [
+    {
+      type = "insecureAcceptAnything";
+    }
+  ]);
+in
 {
-  options.dotfiles.host = {
-    name = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
-      default = null;
-      description = "Optional Home Manager host identity.";
+  options.dotfiles = {
+    host = {
+      name = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = "Optional Home Manager host identity.";
+      };
+
+      role = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = "Optional Home Manager host role.";
+      };
+
+      graphical.enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Whether this Home Manager profile is graphical-capable.";
+      };
+
+      laptop.enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Whether this Home Manager profile is laptop-specific.";
+      };
+
+      wsl.enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Whether this Home Manager profile targets WSL.";
+      };
+
+      userSystemd.enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = "Whether this host supports Home Manager user systemd units.";
+      };
     };
 
-    role = lib.mkOption {
-      type = lib.types.nullOr lib.types.str;
-      default = null;
-      description = "Optional Home Manager host role.";
-    };
+    podman = {
+      apiSocket.enable = lib.mkEnableOption "the rootless Podman API socket";
 
-    graphical.enable = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = "Whether this Home Manager profile is graphical-capable.";
-    };
-
-    laptop.enable = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = "Whether this Home Manager profile is laptop-specific.";
-    };
-
-    wsl.enable = lib.mkOption {
-      type = lib.types.bool;
-      default = false;
-      description = "Whether this Home Manager profile targets WSL.";
-    };
-
-    userSystemd.enable = lib.mkOption {
-      type = lib.types.bool;
-      default = true;
-      description = "Whether this host supports Home Manager user systemd units.";
+      allowedUnsignedRegistries = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [
+          "docker.io"
+          "ghcr.io"
+        ];
+        description = ''
+          Fully qualified registries temporarily permitted without signature
+          verification. Unspecified registries are rejected by default.
+        '';
+      };
     };
   };
 
@@ -69,18 +94,31 @@
     ];
 
     xdg.configFile."containers/registries.conf".text = ''
-      unqualified-search-registries = ["docker.io"]
+      unqualified-search-registries = []
+      short-name-mode = "enforcing"
     '';
 
     xdg.configFile."containers/policy.json".text = builtins.toJSON {
       default = [
         {
-          type = "insecureAcceptAnything";
+          type = "reject";
         }
       ];
+      transports = {
+        docker = unsignedRegistryPolicy;
+        "containers-storage" = {
+          "" = [
+            {
+              type = "insecureAcceptAnything";
+            }
+          ];
+        };
+      };
     };
 
-    systemd.user.sockets.podman = lib.mkIf config.dotfiles.host.userSystemd.enable {
+    systemd.user.sockets.podman = lib.mkIf (
+      config.dotfiles.host.userSystemd.enable && config.dotfiles.podman.apiSocket.enable
+    ) {
       Unit = {
         Description = "Podman API Socket";
         Documentation = [ "man:podman-system-service(1)" ];
@@ -89,7 +127,9 @@
       Install.WantedBy = [ "sockets.target" ];
     };
 
-    systemd.user.services.podman = lib.mkIf config.dotfiles.host.userSystemd.enable {
+    systemd.user.services.podman = lib.mkIf (
+      config.dotfiles.host.userSystemd.enable && config.dotfiles.podman.apiSocket.enable
+    ) {
       Unit = {
         Description = "Podman API Service";
         Requires = [ "podman.socket" ];

--- a/modules/home/secrets.nix
+++ b/modules/home/secrets.nix
@@ -1,4 +1,37 @@
-{ config, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  mkScopedSecretWrapper =
+    {
+      name,
+      environmentVariable,
+      secretPath,
+    }:
+    pkgs.writeShellApplication {
+      inherit name;
+      text = ''
+        if [ "$#" -eq 0 ]; then
+          echo "usage: ${name} <command> [args...]" >&2
+          exit 64
+        fi
+
+        secret_path=${lib.escapeShellArg secretPath}
+        if [ ! -f "$secret_path" ] || [ ! -r "$secret_path" ]; then
+          echo "${name}: secret file is unavailable: $secret_path" >&2
+          exit 66
+        fi
+
+        secret_value="$(<"$secret_path")"
+        export ${environmentVariable}="$secret_value"
+        unset secret_value secret_path
+        exec "$@"
+      '';
+    };
+in
 {
   sops = {
     defaultSopsFile = ../../secrets.yaml;
@@ -6,17 +39,11 @@
     gnupg.home = "${config.home.homeDirectory}/.gnupg";
 
     secrets = {
-      github_token = { };
-      openai_api_key = { };
-      anthropic_api_key = { };
+      github_token.mode = "0400";
+      openai_api_key.mode = "0400";
+      anthropic_api_key.mode = "0400";
     };
   };
-
-  sops.templates."user-runtime-secrets.env".content = ''
-    export GITHUB_TOKEN=${config.sops.placeholder.github_token}
-    export OPENAI_API_KEY=${config.sops.placeholder.openai_api_key}
-    export ANTHROPIC_API_KEY=${config.sops.placeholder.anthropic_api_key}
-  '';
 
   home.sessionVariables = {
     GITHUB_TOKEN_PATH = config.sops.secrets.github_token.path;
@@ -24,9 +51,21 @@
     ANTHROPIC_API_KEY_PATH = config.sops.secrets.anthropic_api_key.path;
   };
 
-  home.file.".config/zsh/config.d/10-user-runtime-secrets.zsh".text = ''
-    if [ -r "${config.sops.templates."user-runtime-secrets.env".path}" ]; then
-      source "${config.sops.templates."user-runtime-secrets.env".path}"
-    fi
-  '';
+  home.packages = [
+    (mkScopedSecretWrapper {
+      name = "with-github-token";
+      environmentVariable = "GITHUB_TOKEN";
+      secretPath = config.sops.secrets.github_token.path;
+    })
+    (mkScopedSecretWrapper {
+      name = "with-openai-key";
+      environmentVariable = "OPENAI_API_KEY";
+      secretPath = config.sops.secrets.openai_api_key.path;
+    })
+    (mkScopedSecretWrapper {
+      name = "with-anthropic-key";
+      environmentVariable = "ANTHROPIC_API_KEY";
+      secretPath = config.sops.secrets.anthropic_api_key.path;
+    })
+  ];
 }


### PR DESCRIPTION
## Summary

- stops exporting GitHub, OpenAI, and Anthropic credentials into every interactive shell;
- exposes only secret-file paths by default;
- adds explicit per-command credential wrappers;
- sets materialized secret modes to `0400`;
- disables unqualified container image resolution;
- changes containers/image policy from global allow to default reject with narrowly scoped temporary registry exceptions;
- makes the rootless Podman API socket opt-in instead of always active.

## Security impact

Normal shells, editors, build tools, package hooks, and unrelated child processes no longer inherit every provider credential. Container image sources must be fully qualified, unspecified registries fail closed, and ordinary user processes no longer automatically receive a Podman control socket.

Addresses the immediate containment portions of #145 and #146. Those issues remain open for consumer migration, token rotation decisions, signed-image policy, and removal of temporary unsigned registry exceptions.

## Validation

- [ ] Home Manager evaluation
- [ ] repository Nix checks
- [ ] normal shell has `*_PATH` variables but no raw provider tokens
- [ ] `with-github-token`, `with-openai-key`, and `with-anthropic-key` execute scoped child commands
- [ ] unqualified image pulls fail
- [ ] qualified Docker Hub and GHCR pulls remain available during the temporary unsigned compatibility window
- [ ] Podman API socket is absent unless explicitly enabled
