### PR TITLE
Add Waybar disk space widget

### DIFF
--- a/files/home/.config/waybar/config-technetium.jsonc
+++ b/files/home/.config/waybar/config-technetium.jsonc
@@ -25,6 +25,7 @@
         "power-profiles-daemon",
         "cpu",
         "memory",
+        "custom/disk",
         "temperature",
         "custom/fans",
         "custom/nvidia-gpu",
@@ -77,6 +78,13 @@
     "memory": {
         "format": "{}% ",
         "on-click": "alacritty --title 'btop' -e sh -c 'btop'"
+    },
+    "custom/disk": {
+        "exec": "~/.config/waybar/scripts/disk-space",
+        "interval": 30,
+        "return-type": "json",
+        "format": "{}",
+        "tooltip": true
     },
     "backlight": {
         "device": "intel_backlight",

--- a/files/home/.config/waybar/config.jsonc
+++ b/files/home/.config/waybar/config.jsonc
@@ -27,6 +27,7 @@
         "power-profiles-daemon",
         "cpu",
         "memory",
+        "custom/disk",
         "temperature",
         "custom/fans",
         "custom/nvidia-gpu",
@@ -77,6 +78,13 @@
     "memory": {
         "format": "{}% ",
         "on-click": "alacritty --title 'btop' -e sh -c 'btop'"
+    },
+    "custom/disk": {
+        "exec": "~/.config/waybar/scripts/disk-space",
+        "interval": 30,
+        "return-type": "json",
+        "format": "{}",
+        "tooltip": true
     },
     "backlight": {
         "device": "intel_backlight",

--- a/files/home/.config/waybar/scripts/disk-space
+++ b/files/home/.config/waybar/scripts/disk-space
@@ -22,6 +22,7 @@ human_bytes() {
 read -r root_size root_used root_free root_percent < <(
   df -B1 --output=size,used,avail,pcent / | awk 'NR == 2 { gsub(/%/, "", $4); print $1, $2, $3, $4 }'
 )
+root_device_id=$(findmnt --noheadings --output MAJ:MIN --target / | awk 'NR == 1 { print $1 }')
 
 state=normal
 if (( root_percent >= critical_percent || root_free <= critical_free_bytes )); then
@@ -32,11 +33,15 @@ fi
 
 tooltip=$(printf '<b>Disk usage</b>\n%-22s %10s %10s %6s\n' 'Mount' 'Used' 'Free' 'Use')
 tooltip+=$'\n'
-root_seen=false
+tooltip+=$(printf '%-22s %10s %10s %5s%%' \
+  '/' "$(human_bytes "$root_used")" "$(human_bytes "$root_free")" "$root_percent")
+tooltip+=$'\n'
 
-declare -A seen_sources=()
-while IFS=$'\t' read -r source fstype target; do
-  [[ -n "$source" && -n "$target" ]] || continue
+declare -A seen_devices=()
+seen_devices[$root_device_id]=1
+
+while IFS=$'\t' read -r device_id fstype target; do
+  [[ -n "$device_id" && -n "$target" ]] || continue
 
   case "$fstype" in
     btrfs|ext2|ext3|ext4|xfs|zfs|f2fs|jfs|reiserfs|bcachefs|ntfs|ntfs3|exfat|vfat) ;;
@@ -44,13 +49,12 @@ while IFS=$'\t' read -r source fstype target; do
   esac
 
   case "$target" in
-    /nix/store|/run/*|/proc/*|/sys/*|/dev/*|/var/lib/containers/*|/var/lib/docker/*) continue ;;
+    /|/nix/store|/run/*|/proc/*|/sys/*|/dev/*|/var/lib/containers/*|/var/lib/docker/*) continue ;;
   esac
 
-  # Btrfs subvolumes often expose the same backing device at many mountpoints.
-  # Keep the first mount (normally /) so totals are not represented repeatedly.
-  [[ -z ${seen_sources[$source]+x} ]] || continue
-  seen_sources[$source]=1
+  # Device identity avoids presenting Btrfs subvolumes as separate disks.
+  [[ -z ${seen_devices[$device_id]+x} ]] || continue
+  seen_devices[$device_id]=1
 
   if ! read -r size used free percent < <(
     df -B1 --output=size,used,avail,pcent "$target" 2>/dev/null |
@@ -59,18 +63,10 @@ while IFS=$'\t' read -r source fstype target; do
     continue
   fi
 
-  [[ "$target" == / ]] && root_seen=true
   tooltip+=$(printf '%-22s %10s %10s %5s%%' \
     "$target" "$(human_bytes "$used")" "$(human_bytes "$free")" "$percent")
   tooltip+=$'\n'
-done < <(findmnt --real --raw --noheadings --output SOURCE,FSTYPE,TARGET | tr -s ' ' '\t')
-
-# Ensure the system filesystem is always represented even if findmnt output is unusual.
-if [[ "$root_seen" == false ]]; then
-  tooltip+=$(printf '%-22s %10s %10s %5s%%' \
-    '/' "$(human_bytes "$root_used")" "$(human_bytes "$root_free")" "$root_percent")
-  tooltip+=$'\n'
-fi
+done < <(findmnt --real --raw --noheadings --output MAJ:MIN,FSTYPE,TARGET | tr -s ' ' '\t')
 
 text=$(printf '󰋊 %s%%' "$root_percent")
 printf '{"text":"%s","tooltip":"%s","class":"%s","percentage":%s}\n' \

--- a/files/home/.config/waybar/scripts/disk-space
+++ b/files/home/.config/waybar/scripts/disk-space
@@ -7,8 +7,8 @@ warning_free_bytes=${WAYBAR_DISK_WARNING_FREE_BYTES:-42949672960}
 critical_free_bytes=${WAYBAR_DISK_CRITICAL_FREE_BYTES:-16106127360}
 
 json_escape() {
-  local value=${1//$'\\'/\\\\}
-  value=${value//$'"'/\\"}
+  local value=${1//\\/\\\\}
+  value=${value//"/\\"}
   value=${value//$'\n'/\\n}
   value=${value//$'\r'/\\r}
   value=${value//$'\t'/\\t}
@@ -31,6 +31,8 @@ elif (( root_percent >= warning_percent || root_free <= warning_free_bytes )); t
 fi
 
 tooltip=$(printf '<b>Disk usage</b>\n%-22s %10s %10s %6s\n' 'Mount' 'Used' 'Free' 'Use')
+tooltip+=$'\n'
+root_seen=false
 
 declare -A seen_sources=()
 while IFS=$'\t' read -r source fstype target; do
@@ -57,14 +59,17 @@ while IFS=$'\t' read -r source fstype target; do
     continue
   fi
 
-  tooltip+=$(printf '%-22s %10s %10s %5s%%\n' \
+  [[ "$target" == / ]] && root_seen=true
+  tooltip+=$(printf '%-22s %10s %10s %5s%%' \
     "$target" "$(human_bytes "$used")" "$(human_bytes "$free")" "$percent")
-done < <(findmnt --real --raw --noheadings --output SOURCE,FSTYPE,TARGET --tab-file /proc/self/mountinfo | tr -s ' ' '\t')
+  tooltip+=$'\n'
+done < <(findmnt --real --raw --noheadings --output SOURCE,FSTYPE,TARGET | tr -s ' ' '\t')
 
 # Ensure the system filesystem is always represented even if findmnt output is unusual.
-if [[ "$tooltip" != *$'\n/'* ]]; then
-  tooltip+=$(printf '%-22s %10s %10s %5s%%\n' \
+if [[ "$root_seen" == false ]]; then
+  tooltip+=$(printf '%-22s %10s %10s %5s%%' \
     '/' "$(human_bytes "$root_used")" "$(human_bytes "$root_free")" "$root_percent")
+  tooltip+=$'\n'
 fi
 
 text=$(printf '󰋊 %s%%' "$root_percent")

--- a/files/home/.config/waybar/scripts/disk-space
+++ b/files/home/.config/waybar/scripts/disk-space
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+warning_percent=${WAYBAR_DISK_WARNING_PERCENT:-80}
+critical_percent=${WAYBAR_DISK_CRITICAL_PERCENT:-90}
+warning_free_bytes=${WAYBAR_DISK_WARNING_FREE_BYTES:-42949672960}
+critical_free_bytes=${WAYBAR_DISK_CRITICAL_FREE_BYTES:-16106127360}
+
+json_escape() {
+  local value=${1//$'\\'/\\\\}
+  value=${value//$'"'/\\"}
+  value=${value//$'\n'/\\n}
+  value=${value//$'\r'/\\r}
+  value=${value//$'\t'/\\t}
+  printf '%s' "$value"
+}
+
+human_bytes() {
+  numfmt --to=iec-i --suffix=B --format='%.1f' "$1" 2>/dev/null || printf '%sB' "$1"
+}
+
+read -r root_size root_used root_free root_percent < <(
+  df -B1 --output=size,used,avail,pcent / | awk 'NR == 2 { gsub(/%/, "", $4); print $1, $2, $3, $4 }'
+)
+
+state=normal
+if (( root_percent >= critical_percent || root_free <= critical_free_bytes )); then
+  state=critical
+elif (( root_percent >= warning_percent || root_free <= warning_free_bytes )); then
+  state=warning
+fi
+
+tooltip=$(printf '<b>Disk usage</b>\n%-22s %10s %10s %6s\n' 'Mount' 'Used' 'Free' 'Use')
+
+declare -A seen_sources=()
+while IFS=$'\t' read -r source fstype target; do
+  [[ -n "$source" && -n "$target" ]] || continue
+
+  case "$fstype" in
+    btrfs|ext2|ext3|ext4|xfs|zfs|f2fs|jfs|reiserfs|bcachefs|ntfs|ntfs3|exfat|vfat) ;;
+    *) continue ;;
+  esac
+
+  case "$target" in
+    /nix/store|/run/*|/proc/*|/sys/*|/dev/*|/var/lib/containers/*|/var/lib/docker/*) continue ;;
+  esac
+
+  # Btrfs subvolumes often expose the same backing device at many mountpoints.
+  # Keep the first mount (normally /) so totals are not represented repeatedly.
+  [[ -z ${seen_sources[$source]+x} ]] || continue
+  seen_sources[$source]=1
+
+  if ! read -r size used free percent < <(
+    df -B1 --output=size,used,avail,pcent "$target" 2>/dev/null |
+      awk 'NR == 2 { gsub(/%/, "", $4); print $1, $2, $3, $4 }'
+  ); then
+    continue
+  fi
+
+  tooltip+=$(printf '%-22s %10s %10s %5s%%\n' \
+    "$target" "$(human_bytes "$used")" "$(human_bytes "$free")" "$percent")
+done < <(findmnt --real --raw --noheadings --output SOURCE,FSTYPE,TARGET --tab-file /proc/self/mountinfo | tr -s ' ' '\t')
+
+# Ensure the system filesystem is always represented even if findmnt output is unusual.
+if [[ "$tooltip" != *$'\n/'* ]]; then
+  tooltip+=$(printf '%-22s %10s %10s %5s%%\n' \
+    '/' "$(human_bytes "$root_used")" "$(human_bytes "$root_free")" "$root_percent")
+fi
+
+text=$(printf '󰋊 %s%%' "$root_percent")
+printf '{"text":"%s","tooltip":"%s","class":"%s","percentage":%s}\n' \
+  "$(json_escape "$text")" \
+  "$(json_escape "${tooltip%$'\n'}")" \
+  "$state" \
+  "$root_percent"

--- a/files/home/.config/waybar/style.css
+++ b/files/home/.config/waybar/style.css
@@ -45,7 +45,7 @@ window#waybar {
     color: #7aa2f7;
 }
 
-#battery, #clock, #cpu, #memory, #temperature, #backlight, #custom-backlight, #network, #pulseaudio, #custom-music, #custom-media, #custom-bluetooth, #tray, #mode, #idle_inhibitor, #custom-power, #language {
+#battery, #clock, #cpu, #memory, #temperature, #backlight, #custom-backlight, #network, #pulseaudio, #custom-music, #custom-media, #custom-bluetooth, #custom-disk, #tray, #mode, #idle_inhibitor, #custom-power, #language {
     padding: 0 14px;
     margin: 4px 2px;
     border-radius: 8px;
@@ -65,6 +65,23 @@ window#waybar {
 #custom-music,
 #custom-media {
     color: #c0caf5;
+}
+
+#custom-disk {
+    color: #b4f9f8;
+}
+
+#custom-disk.warning {
+    color: #e0af68;
+}
+
+#custom-disk.critical {
+    color: #f38ba8;
+    animation-name: blink;
+    animation-duration: 0.5s;
+    animation-timing-function: linear;
+    animation-iteration-count: infinite;
+    animation-direction: alternate;
 }
 
 #network {

--- a/modules/home/waybar.nix
+++ b/modules/home/waybar.nix
@@ -46,5 +46,9 @@ in
       source = ../../files/home/.config/waybar/scripts/nvidia-gpu;
       executable = true;
     };
+    xdg.configFile."waybar/scripts/disk-space" = {
+      source = ../../files/home/.config/waybar/scripts/disk-space;
+      executable = true;
+    };
   };
 }


### PR DESCRIPTION
## What changed

- add a custom Waybar disk-space helper showing root filesystem usage
- show a hover breakdown for persistent mounted filesystems
- deduplicate Btrfs subvolumes and other mounts sharing the same backing device
- add warning and critical states based on both percentage used and absolute free space
- enable the widget for workstation and laptop Waybar profiles
- install the helper declaratively through the Home Manager module

## Thresholds

- warning: at least 80% used or at most 40 GiB free
- critical: at least 90% used or at most 15 GiB free

Thresholds can be overridden through `WAYBAR_DISK_*` environment variables.

## Validation

- reviewed the branch diff against `main`
- validated the helper syntax and JSON output locally using representative mount data
- kept presentation-mode Waybar unchanged
