### PR TITLE
Remove conflicting MuseScore Super+R shortcut

### DIFF
--- a/modules/home/music.nix
+++ b/modules/home/music.nix
@@ -145,11 +145,6 @@ in
       };
     };
 
-    xdg.configFile."hypr/custom.d/40-guitar-pro.conf".text = ''
-      # Open the Guitar Pro reader through its managed desktop entry.
-      bind = SUPER, R, exec, ${pkgs.gtk3}/bin/gtk-launch guitar-pro-reader
-    '';
-
     # Populate the standard per-user plugin directories that REAPER scans.
     # Recursive linking allows unrelated manually installed plugins to coexist.
     home.file = {


### PR DESCRIPTION
## What changed

Removed the generated Hyprland binding that launched the Guitar Pro reader on `Super+R`.

## Why

`Super+R` is reserved for the normal run/application menu. The music module unintentionally overrode that global launcher shortcut, causing MuseScore to start directly.

## Impact

MuseScore and the managed Guitar Pro desktop entry remain available through the application launcher and file associations. Only the direct keyboard binding is removed.

## Validation

Reviewed the branch diff: one file changed, five lines removed, with no unrelated modifications.