### PR TITLE
Improve Waybar disk mount visibility

### DIFF
--- a/docs/waybar-disk-widget.md
+++ b/docs/waybar-disk-widget.md
@@ -1,0 +1,7 @@
+# Waybar disk widget
+
+The custom disk widget intentionally replaces Waybar's built-in `disk` module. Only `custom/disk` should be declared in the active Waybar configuration.
+
+The widget reports root filesystem pressure in the bar and lists distinct persistent mounted devices in its tooltip. NTFS mounts provided by `ntfs-3g` are commonly reported by Linux as `fuseblk`, so `fuseblk` must remain in the supported filesystem allowlist.
+
+A follow-up enhancement should add bounded, read-only Btrfs details such as filesystem allocation, device count, estimated free space, and quota/qgroup status. The implementation must fail closed when Btrfs tooling is unavailable or access is denied, and must avoid blocking Waybar refreshes.

--- a/files/home/.config/waybar/scripts/disk-space
+++ b/files/home/.config/waybar/scripts/disk-space
@@ -44,7 +44,7 @@ while IFS=$'\t' read -r device_id fstype target; do
   [[ -n "$device_id" && -n "$target" ]] || continue
 
   case "$fstype" in
-    btrfs|ext2|ext3|ext4|xfs|zfs|f2fs|jfs|reiserfs|bcachefs|ntfs|ntfs3|exfat|vfat) ;;
+    btrfs|ext2|ext3|ext4|xfs|zfs|f2fs|jfs|reiserfs|bcachefs|ntfs|ntfs3|fuseblk|exfat|vfat) ;;
     *) continue ;;
   esac
 

--- a/files/home/.config/waybar/style.css
+++ b/files/home/.config/waybar/style.css
@@ -112,7 +112,7 @@ window#waybar {
 #idle_inhibitor {
     font-family: "Symbols Nerd Font Mono", "JetBrainsMono Nerd Font Mono", "JetBrainsMono Nerd Font";
     font-size: 20px;
-    color: #bb9af7;
+    color: #7aa2f7;
     padding: 0 10px;
     min-width: 24px;
 }


### PR DESCRIPTION
## What changed

- include `fuseblk` in the disk widget filesystem allowlist so NTFS volumes mounted through `ntfs-3g` appear in the hover breakdown
- keep the existing RAM percentage icon unchanged
- change the idle-inhibitor accent from purple to blue so it does not sit beside the purple audio widget
- document that `custom/disk` replaces Waybar's built-in disk module
- document the bounded Btrfs follow-up tracked in #154

## Why

Linux commonly reports `ntfs-3g` mounts as `fuseblk`, so `/mnt/tmp`, `/mnt/isotope`, `/mnt/resevoir`, and `/mnt/windows` were filtered out despite being persistent disks. The right-side color sequence also placed two purple widgets beside one another.

## Validation

- branch is current with `main`
- confirmed no built-in `disk` module is declared in either Waybar profile; only `custom/disk` remains
- reviewed the right-side module order and assigned distinct colors to adjacent explicitly styled widgets
- RAM retains its original icon and behavior
- Btrfs enhancement remains tracked separately in #154
