### PR TITLE
Add Btrfs root details to Waybar disk tooltip

### DIFF
--- a/docs/waybar-disk-widget.md
+++ b/docs/waybar-disk-widget.md
@@ -2,6 +2,6 @@
 
 The custom disk widget intentionally replaces Waybar's built-in `disk` module. Only `custom/disk` should be declared in the active Waybar configuration.
 
-The widget reports root filesystem pressure in the bar and lists distinct persistent mounted devices in its tooltip. NTFS mounts provided by `ntfs-3g` are commonly reported by Linux as `fuseblk`, so `fuseblk` must remain in the supported filesystem allowlist.
+The widget reports root filesystem pressure in the bar and lists distinct persistent mounted devices in its tooltip. Boot mounts are intentionally omitted. NTFS mounts provided by `ntfs-3g` are commonly reported by Linux as `fuseblk`, so `fuseblk` must remain in the supported filesystem allowlist.
 
-A follow-up enhancement should add bounded, read-only Btrfs details such as filesystem allocation, device count, estimated free space, and quota/qgroup status. The implementation must fail closed when Btrfs tooling is unavailable or access is denied, and must avoid blocking Waybar refreshes.
+When `/` is Btrfs and the `btrfs` tools are available, the tooltip also shows bounded, read-only root details: backing source, device count, device size, allocated and unallocated space, estimated free space, missing space, data and metadata ratios, and quota/qgroup status. Every Btrfs command has a two-second timeout, requires no privilege escalation, and degrades to an unavailable status rather than blocking Waybar.

--- a/files/home/.config/waybar/scripts/disk-space
+++ b/files/home/.config/waybar/scripts/disk-space
@@ -21,7 +21,7 @@ human_bytes() {
 
 btrfs_metric() {
   local label=$1
-  awk -F: -v label="$label" '$1 ~ "^[[:space:]]*" label "$" { value=$2; gsub(/^[[:space:]]+|[[:space:]]+$/, "", value); print value; exit }'
+  awk -F: -v label="$label" '{ key=$1; gsub(/^[[:space:]]+|[[:space:]]+$/, "", key); if (key == label) { value=$2; gsub(/^[[:space:]]+|[[:space:]]+$/, "", value); print value; exit } }'
 }
 
 read -r root_size root_used root_free root_percent < <(
@@ -104,11 +104,10 @@ if [[ "$root_fstype" == btrfs ]]; then
       tooltip+=$'Details: unavailable\n'
     fi
 
-    quota_output=$(timeout 2s btrfs qgroup show -reF --raw / 2>&1 || true)
-    if [[ "$quota_output" == *"not enabled"* ]]; then
-      quota_status=disabled
-    elif [[ -n "$quota_output" ]] && [[ "$quota_output" != *"ERROR:"* ]]; then
+    if quota_output=$(timeout 2s btrfs qgroup show -reF --raw / 2>&1); then
       quota_status=enabled
+    elif [[ "$quota_output" == *"not enabled"* ]]; then
+      quota_status=disabled
     else
       quota_status=unavailable
     fi

--- a/files/home/.config/waybar/scripts/disk-space
+++ b/files/home/.config/waybar/scripts/disk-space
@@ -24,6 +24,10 @@ btrfs_metric() {
   awk -F: -v label="$label" '{ key=$1; gsub(/^[[:space:]]+|[[:space:]]+$/, "", key); if (key == label) { value=$2; gsub(/^[[:space:]]+|[[:space:]]+$/, "", value); print value; exit } }'
 }
 
+btrfs_bytes_metric() {
+  btrfs_metric "$1" | awk '{ print $1 }'
+}
+
 read -r root_size root_used root_free root_percent < <(
   df -B1 --output=size,used,avail,pcent / | awk 'NR == 2 { gsub(/%/, "", $4); print $1, $2, $3, $4 }'
 )
@@ -84,14 +88,15 @@ if [[ "$root_fstype" == btrfs ]]; then
     show_output=$(timeout 2s btrfs filesystem show --raw / 2>/dev/null || true)
 
     if [[ -n "$usage_output" ]]; then
-      device_size=$(printf '%s\n' "$usage_output" | btrfs_metric 'Device size')
-      allocated=$(printf '%s\n' "$usage_output" | btrfs_metric 'Device allocated')
-      unallocated=$(printf '%s\n' "$usage_output" | btrfs_metric 'Device unallocated')
-      estimated_free=$(printf '%s\n' "$usage_output" | btrfs_metric 'Free (estimated)')
-      missing=$(printf '%s\n' "$usage_output" | btrfs_metric 'Device missing')
+      device_size=$(printf '%s\n' "$usage_output" | btrfs_bytes_metric 'Device size')
+      allocated=$(printf '%s\n' "$usage_output" | btrfs_bytes_metric 'Device allocated')
+      unallocated=$(printf '%s\n' "$usage_output" | btrfs_bytes_metric 'Device unallocated')
+      estimated_free=$(printf '%s\n' "$usage_output" | btrfs_bytes_metric 'Free (estimated)')
+      missing=$(printf '%s\n' "$usage_output" | btrfs_bytes_metric 'Device missing')
       data_ratio=$(printf '%s\n' "$usage_output" | btrfs_metric 'Data ratio')
       metadata_ratio=$(printf '%s\n' "$usage_output" | btrfs_metric 'Metadata ratio')
       device_count=$(printf '%s\n' "$show_output" | awk '/^[[:space:]]*devid[[:space:]]/ { count++ } END { print count + 0 }')
+      (( device_count > 0 )) || device_count=unknown
 
       tooltip+=$(printf 'Devices: %s  Size: %s\n' "$device_count" "$(human_bytes "${device_size:-0}")")
       tooltip+=$(printf 'Allocated: %s  Unallocated: %s\n' \

--- a/files/home/.config/waybar/scripts/disk-space
+++ b/files/home/.config/waybar/scripts/disk-space
@@ -19,10 +19,17 @@ human_bytes() {
   numfmt --to=iec-i --suffix=B --format='%.1f' "$1" 2>/dev/null || printf '%sB' "$1"
 }
 
+btrfs_metric() {
+  local label=$1
+  awk -F: -v label="$label" '$1 ~ "^[[:space:]]*" label "$" { value=$2; gsub(/^[[:space:]]+|[[:space:]]+$/, "", value); print value; exit }'
+}
+
 read -r root_size root_used root_free root_percent < <(
   df -B1 --output=size,used,avail,pcent / | awk 'NR == 2 { gsub(/%/, "", $4); print $1, $2, $3, $4 }'
 )
 root_device_id=$(findmnt --noheadings --output MAJ:MIN --target / | awk 'NR == 1 { print $1 }')
+root_source=$(findmnt --noheadings --output SOURCE --target / | awk 'NR == 1 { print $1 }')
+root_fstype=$(findmnt --noheadings --output FSTYPE --target / | awk 'NR == 1 { print $1 }')
 
 state=normal
 if (( root_percent >= critical_percent || root_free <= critical_free_bytes )); then
@@ -49,7 +56,7 @@ while IFS=$'\t' read -r device_id fstype target; do
   esac
 
   case "$target" in
-    /|/nix/store|/run/*|/proc/*|/sys/*|/dev/*|/var/lib/containers/*|/var/lib/docker/*) continue ;;
+    /|/boot|/boot/*|/nix/store|/run/*|/proc/*|/sys/*|/dev/*|/var/lib/containers/*|/var/lib/docker/*) continue ;;
   esac
 
   # Device identity avoids presenting Btrfs subvolumes as separate disks.
@@ -67,6 +74,49 @@ while IFS=$'\t' read -r device_id fstype target; do
     "$target" "$(human_bytes "$used")" "$(human_bytes "$free")" "$percent")
   tooltip+=$'\n'
 done < <(findmnt --real --raw --noheadings --output MAJ:MIN,FSTYPE,TARGET | tr -s ' ' '\t')
+
+if [[ "$root_fstype" == btrfs ]]; then
+  tooltip+=$'\n'
+  tooltip+=$(printf '<b>Btrfs root</b>  %s\n' "$root_source")
+
+  if command -v btrfs >/dev/null 2>&1 && command -v timeout >/dev/null 2>&1; then
+    usage_output=$(timeout 2s btrfs filesystem usage -b / 2>/dev/null || true)
+    show_output=$(timeout 2s btrfs filesystem show --raw / 2>/dev/null || true)
+
+    if [[ -n "$usage_output" ]]; then
+      device_size=$(printf '%s\n' "$usage_output" | btrfs_metric 'Device size')
+      allocated=$(printf '%s\n' "$usage_output" | btrfs_metric 'Device allocated')
+      unallocated=$(printf '%s\n' "$usage_output" | btrfs_metric 'Device unallocated')
+      estimated_free=$(printf '%s\n' "$usage_output" | btrfs_metric 'Free (estimated)')
+      missing=$(printf '%s\n' "$usage_output" | btrfs_metric 'Device missing')
+      data_ratio=$(printf '%s\n' "$usage_output" | btrfs_metric 'Data ratio')
+      metadata_ratio=$(printf '%s\n' "$usage_output" | btrfs_metric 'Metadata ratio')
+      device_count=$(printf '%s\n' "$show_output" | awk '/^[[:space:]]*devid[[:space:]]/ { count++ } END { print count + 0 }')
+
+      tooltip+=$(printf 'Devices: %s  Size: %s\n' "$device_count" "$(human_bytes "${device_size:-0}")")
+      tooltip+=$(printf 'Allocated: %s  Unallocated: %s\n' \
+        "$(human_bytes "${allocated:-0}")" "$(human_bytes "${unallocated:-0}")")
+      tooltip+=$(printf 'Estimated free: %s  Missing: %s\n' \
+        "$(human_bytes "${estimated_free:-0}")" "$(human_bytes "${missing:-0}")")
+      tooltip+=$(printf 'Data ratio: %s  Metadata ratio: %s\n' \
+        "${data_ratio:-unknown}" "${metadata_ratio:-unknown}")
+    else
+      tooltip+=$'Details: unavailable\n'
+    fi
+
+    quota_output=$(timeout 2s btrfs qgroup show -reF --raw / 2>&1 || true)
+    if [[ "$quota_output" == *"not enabled"* ]]; then
+      quota_status=disabled
+    elif [[ -n "$quota_output" ]] && [[ "$quota_output" != *"ERROR:"* ]]; then
+      quota_status=enabled
+    else
+      quota_status=unavailable
+    fi
+    tooltip+=$(printf 'Quotas: %s\n' "$quota_status")
+  else
+    tooltip+=$'Details: btrfs tools unavailable\n'
+  fi
+fi
 
 text=$(printf '󰋊 %s%%' "$root_percent")
 printf '{"text":"%s","tooltip":"%s","class":"%s","percentage":%s}\n' \


### PR DESCRIPTION
## What changed

- omit `/boot` and nested boot mounts from the disk tooltip
- add a Btrfs root section when `/` uses Btrfs
- show root backing source, device count, physical size, allocated and unallocated space, estimated free space, missing space, data/metadata ratios, and quota status
- bound every Btrfs command to two seconds
- degrade cleanly when Btrfs tools or permissions are unavailable
- update the disk widget documentation

## Why

The boot filesystem adds little operational value to the persistent-disk breakdown, while Btrfs allocation and quota information better explains the real storage pressure on the root filesystem than `df` alone.

## Validation

- reviewed the branch diff against `main`
- corrected literal parsing for labels containing parentheses
- normalized Btrfs byte values before unit formatting
- preserved the existing root warning/critical behavior and NTFS mount support
- no privilege escalation is used

Closes #154