### PR TITLE
Deploy Waybar Bluetooth script via Home Manager

### DIFF
--- a/modules/home/waybar.nix
+++ b/modules/home/waybar.nix
@@ -50,5 +50,9 @@ in
       source = ../../files/home/.config/waybar/scripts/disk-space;
       executable = true;
     };
+    xdg.configFile."waybar/scripts/bluetooth" = {
+      source = ../../files/home/.config/waybar/scripts/bluetooth;
+      executable = true;
+    };
   };
 }

--- a/scripts/verify-session-files.sh
+++ b/scripts/verify-session-files.sh
@@ -111,6 +111,14 @@ printf -- '\n--- Waybar templates ---\n'
 check_exists files/home/.config/waybar/config.jsonc
 check_exists files/home/.config/waybar/config-technetium.jsonc
 
+# --- Waybar scripts ---
+printf -- '\n--- Waybar scripts ---\n'
+for path in files/home/.config/waybar/scripts/*; do
+	[ -f "$path" ] || continue
+	check_bash "$path"
+	check_contains modules/home/waybar.nix "waybar/scripts/$(basename "$path")"
+done
+
 # --- OBS assets ---
 printf -- '\n--- OBS assets ---\n'
 check_exists files/home/.local/share/dubnium/obs/v1/profile/basic.ini


### PR DESCRIPTION
## What changed
- declare `waybar/scripts/bluetooth` in `modules/home/waybar.nix` and mark it executable
- verify every tracked Waybar script passes `bash -n`
- verify every tracked Waybar script has a corresponding Home Manager deployment declaration

## Root cause
The Waybar configuration referenced `~/.config/waybar/scripts/bluetooth`, and the script existed in the repository, but `modules/home/waybar.nix` only deployed `fans`, `nvidia-gpu`, and `disk-space`. Home Manager therefore never created the Bluetooth script at runtime, causing Waybar's repeated `No such file or directory` errors and no rendered Bluetooth widget.

## Impact
After the Home Manager configuration is applied, `~/.config/waybar/scripts/bluetooth` will exist and Waybar can render the Bluetooth status module. The regression check should prevent future tracked Waybar scripts from being omitted from deployment.