### PR TITLE
feat(waybar): seek music with mouse wheel

### DIFF
--- a/files/home/.config/waybar/config-technetium.jsonc
+++ b/files/home/.config/waybar/config-technetium.jsonc
@@ -140,7 +140,9 @@
         "on-click-right": "playerctl --player=mpv next",
         "on-click-middle": "playerctl --player=mpv previous",
         "on-click-backward": "~/.local/bin/music-eq",
-        "on-click-forward": "~/.local/bin/music-eq service"
+        "on-click-forward": "~/.local/bin/music-eq service",
+        "on-scroll-up": "playerctl --player=mpv position 10+",
+        "on-scroll-down": "playerctl --player=mpv position 10-"
     },
     "battery": {
         "states": {

--- a/files/home/.config/waybar/config.jsonc
+++ b/files/home/.config/waybar/config.jsonc
@@ -19,9 +19,7 @@
         "hyprland/window"
     ],
     "modules-right": [
-        "custom/music-seek-backward",
         "custom/music",
-        "custom/music-seek-forward",
         "idle_inhibitor",
         "pulseaudio",
         "power-profiles-daemon",
@@ -122,11 +120,6 @@
         "on-click": "blueman-manager",
         "on-click-right": "bluetoothctl power $(bluetoothctl show | awk '/Powered:/{print $2}' | grep -q yes && echo off || echo on)"
     },
-    "custom/music-seek-backward": {
-        "format": "<",
-        "tooltip-format": "Seek backward 10 seconds",
-        "on-click": "playerctl --player=mpv position 10-"
-    },
     "custom/music": {
         "exec": "~/.local/bin/music-status",
         "interval": 1,
@@ -137,12 +130,9 @@
         "on-click-right": "playerctl --player=mpv next",
         "on-click-middle": "playerctl --player=mpv previous",
         "on-click-backward": "~/.local/bin/music-eq",
-        "on-click-forward": "~/.local/bin/music-eq service"
-    },
-    "custom/music-seek-forward": {
-        "format": ">",
-        "tooltip-format": "Seek forward 10 seconds",
-        "on-click": "playerctl --player=mpv position 10+"
+        "on-click-forward": "~/.local/bin/music-eq service",
+        "on-scroll-up": "playerctl --player=mpv position 10+",
+        "on-scroll-down": "playerctl --player=mpv position 10-"
     },
     "pulseaudio": {
         "format": "{volume}% {icon}  {format_source}",


### PR DESCRIPTION
## Summary

- remove the visible `<` and `>` seek controls from the Dubnium Waybar
- seek forward 10 seconds when scrolling up over the music widget
- seek backward 10 seconds when scrolling down over the music widget
- apply the same scroll behavior to the Technetium music widget
- preserve existing left/right/middle and side-button bindings

## Why

The separate seek buttons consume bar space and duplicate an interaction that fits naturally on the music widget itself. This keeps the existing 10-second seek step while making the control more compact.

## Validation

- compared `agent/waybar-music-scroll-seek` against `main`
- confirmed only the two Waybar config files changed
- confirmed the branch is based directly on current `main` and is not behind it