### PR TITLE
Enable session SSH agent and delegate OpenWork access

### DIFF
--- a/files/home/.local/bin/dub-session-doctor
+++ b/files/home/.local/bin/dub-session-doctor
@@ -98,6 +98,28 @@ else
   warn 'cliphist service not active'
 fi
 
+if command -v systemctl >/dev/null 2>&1; then
+  if systemctl --user is-enabled --quiet ssh-agent.service; then
+    ok 'ssh-agent service enabled'
+  else
+    warn 'ssh-agent service not enabled'
+  fi
+
+  if systemctl --user is-active --quiet ssh-agent.service; then
+    ok 'ssh-agent service active'
+  else
+    warn 'ssh-agent service not active'
+  fi
+else
+  warn 'systemctl not available; cannot check ssh-agent service'
+fi
+
+if [ -n "${SSH_AUTH_SOCK:-}" ] && [ -S "$SSH_AUTH_SOCK" ]; then
+  ok "SSH_AUTH_SOCK available: $SSH_AUTH_SOCK"
+else
+  warn 'SSH_AUTH_SOCK is unset or does not name a socket'
+fi
+
 meeting_helper="$HOME/.local/libexec/dubnium-meeting-mode"
 if [ -x "$meeting_helper" ]; then
   if meeting_status="$("$meeting_helper" status 2>/dev/null)"; then

--- a/home/ryjen/profiles/dubnium.nix
+++ b/home/ryjen/profiles/dubnium.nix
@@ -10,6 +10,7 @@
   dotfiles.profiles.micrantha.enable = lib.mkDefault false;
   dotfiles.profiles.office.enable = lib.mkDefault true;
   dotfiles.openwork.enable = lib.mkDefault true;
+  dotfiles.openwork.sandbox.allowSshAgent = lib.mkDefault true;
   dotfiles.opsCadence.enable = lib.mkDefault true;
   dotfiles.hypr.adoptedProfile = "dubnium";
 

--- a/home/ryjen/user.example.nix
+++ b/home/ryjen/user.example.nix
@@ -39,6 +39,10 @@
   #   "ghcr.io"
   # ];
 
+  # The OpenSSH agent defaults on when Home Manager user systemd is available.
+  # Disable it when another trusted provider deliberately owns SSH_AUTH_SOCK.
+  # dotfiles.sshAgent.enable = false;
+
   # Bitwarden clients. The Dubnium workstation profile enables both by default;
   # use these explicit selections when maintaining a complete local config.
   # dotfiles.bitwarden.cli.enable = true;

--- a/modules/home/common.nix
+++ b/modules/home/common.nix
@@ -51,6 +51,13 @@ in
       };
     };
 
+    sshAgent.enable = lib.mkOption {
+      type = lib.types.bool;
+      default = config.dotfiles.host.userSystemd.enable;
+      defaultText = lib.literalExpression "config.dotfiles.host.userSystemd.enable";
+      description = "Whether to run the Home Manager OpenSSH agent as a user systemd service.";
+    };
+
     podman = {
       apiSocket.enable = lib.mkEnableOption "the rootless Podman API socket";
 
@@ -69,6 +76,15 @@ in
   };
 
   config = {
+    assertions = [
+      {
+        assertion = !config.dotfiles.sshAgent.enable || config.dotfiles.host.userSystemd.enable;
+        message = "dotfiles.sshAgent.enable requires Home Manager user systemd support.";
+      }
+    ];
+
+    services.ssh-agent.enable = config.dotfiles.sshAgent.enable;
+
     home.packages = with pkgs; [
       bottom
       gdu

--- a/modules/home/openwork.nix
+++ b/modules/home/openwork.nix
@@ -148,11 +148,18 @@ let
       fi
 
       ${lib.optionalString cfg.sandbox.allowSshAgent ''
-        if [[ -n "''${SSH_AUTH_SOCK:-}" && -S "$SSH_AUTH_SOCK" ]]; then
-          ssh_socket_dir="$(dirname "$SSH_AUTH_SOCK")"
+        agent_socket="''${SSH_AUTH_SOCK:-}"
+        ${lib.optionalString config.services.ssh-agent.enable ''
+          if [[ -z "$agent_socket" || ! -S "$agent_socket" ]]; then
+            agent_socket="$XDG_RUNTIME_DIR/${config.services.ssh-agent.socket}"
+          fi
+        ''}
+
+        if [[ -n "$agent_socket" && -S "$agent_socket" ]]; then
+          ssh_socket_dir="$(dirname "$agent_socket")"
           args+=(--dir "$ssh_socket_dir")
-          args+=(--bind "$SSH_AUTH_SOCK" "$SSH_AUTH_SOCK")
-          args+=(--setenv SSH_AUTH_SOCK "$SSH_AUTH_SOCK")
+          args+=(--bind "$agent_socket" "$agent_socket")
+          args+=(--setenv SSH_AUTH_SOCK "$agent_socket")
         fi
       ''}
 
@@ -215,7 +222,7 @@ in
       allowSshAgent = lib.mkOption {
         type = lib.types.bool;
         default = false;
-        description = "Expose SSH_AUTH_SOCK to the OpenWork sandbox";
+        description = "Expose the existing session SSH agent to the OpenWork sandbox";
       };
     };
   };

--- a/scripts/verify-session-files.sh
+++ b/scripts/verify-session-files.sh
@@ -105,6 +105,9 @@ printf -- '\n--- Service declarations ---\n'
 check_contains modules/home/meeting.nix 'dubnium-meeting-mode'
 check_contains modules/home/meeting.nix 'dubnium-cliphist'
 check_contains modules/home/meeting.nix 'RemainAfterExit'
+check_contains modules/home/common.nix 'services\.ssh-agent\.enable'
+check_contains home/ryjen/profiles/dubnium.nix 'openwork\.sandbox\.allowSshAgent'
+check_contains modules/home/openwork.nix 'config\.services\.ssh-agent\.socket'
 
 # --- Waybar templates ---
 printf -- '\n--- Waybar templates ---\n'


### PR DESCRIPTION
## Summary

- enable Home Manager's `ssh-agent.service` by default on hosts that support user systemd
- keep WSL excluded through the existing `dotfiles.host.userSystemd.enable = false` capability
- expose an explicit `dotfiles.sshAgent.enable` override for alternate SSH agent providers
- let OpenWork consume the existing session agent, falling back to Home Manager's canonical runtime socket when the launcher did not inherit `SSH_AUTH_SOCK`
- enable SSH-agent exposure for OpenWork specifically in the Dubnium profile while retaining the sandbox-wide default of `false`
- add session-doctor and static session-contract checks

## Security boundary

OpenWork does not start or own an SSH agent. Agent socket exposure remains an explicit sandbox capability because access to the socket grants authentication/signing authority equivalent to the identities loaded in the agent.

## Validation

- compared branch against `main`: six files changed, no unrelated delta
- verified against Home Manager `release-26.05`: `services.ssh-agent.enable` installs `ssh-agent.service` under `default.target` and uses `$XDG_RUNTIME_DIR/<socket>`
- repository session checks now assert the service declaration, Dubnium OpenWork opt-in, and canonical socket wiring

Local Nix evaluation is not available in this execution environment; CI should provide the full flake evaluation.