### PR TITLE
feat(music): add MPD and rmpc managed library workflow

### DIFF
--- a/checks/verify-configctl-contracts.py
+++ b/checks/verify-configctl-contracts.py
@@ -131,8 +131,16 @@ def validate_music_apps() -> None:
         validator.fail(f"{path}: target_runtime_owner must remain 'home-manager'")
     if mpd.get("renderer_required") is not False:
         validator.fail(f"{path}: renderer_required must be false")
-    if mpd["layout"].get("runtime_includes") != ["custom.d/*.conf", "local.conf"]:
-        validator.fail(f"{path}: runtime_includes must load custom overrides then local.conf")
+
+    expected_includes = [
+        "custom.d/dubnium/*.conf",
+        "custom.d/*.conf",
+        "local.conf",
+    ]
+    if mpd["layout"].get("runtime_includes") != expected_includes:
+        validator.fail(
+            f"{path}: runtime_includes must load promoted profile, live custom, then local overrides"
+        )
 
     validate_compose_app("rmpc", "ron")
     validate_compose_app("beets", "yaml")

--- a/checks/verify-configctl-contracts.py
+++ b/checks/verify-configctl-contracts.py
@@ -1,16 +1,18 @@
 #!/usr/bin/env python3
-"""Extend configctl contract validation with the Hermes contract."""
+"""Extend configctl contract validation with Hermes and managed-music app contracts."""
 
 from __future__ import annotations
 
 import importlib.util
 import sys
+import tomllib
 from pathlib import Path
 from typing import Any
 
 
 REPO_ROOT = Path(sys.argv[1]).resolve() if len(sys.argv) == 2 else Path.cwd().resolve()
 LEGACY_VALIDATOR = REPO_ROOT / "scripts" / "verify-configctl-contracts.py"
+APP_DIR = REPO_ROOT / "contracts" / "configctl" / "apps"
 
 spec = importlib.util.spec_from_file_location("configctl_contracts", LEGACY_VALIDATOR)
 if spec is None or spec.loader is None:
@@ -50,5 +52,96 @@ def validate_common(
     return result
 
 
+def load_music_app(tool: str) -> tuple[Path, dict[str, Any]]:
+    path = APP_DIR / f"{tool}.toml"
+    if not path.is_file():
+        validator.fail(f"missing managed-music app contract: {path.relative_to(REPO_ROOT)}")
+    try:
+        contract = tomllib.loads(path.read_text(encoding="utf-8"))
+    except tomllib.TOMLDecodeError as exc:
+        validator.fail(f"{path}: invalid TOML: {exc}")
+
+    expected_top = {
+        "schema_version": 1,
+        "tool": tool,
+        "owner": "dotfiles",
+        "profile": "dubnium",
+        "executor_may_validate": True,
+        "executor_may_adopt": True,
+        "executor_may_write_outputs": False,
+    }
+    for key, expected in expected_top.items():
+        if contract.get(key) != expected:
+            validator.fail(f"{path}: {key} must be {expected!r}")
+
+    layout = contract.get("layout")
+    if not isinstance(layout, dict):
+        validator.fail(f"{path}: missing [layout] table")
+    if layout.get("standard") != "configctl-v1":
+        validator.fail(f"{path}: layout.standard must be 'configctl-v1'")
+
+    for role in ("source_inputs", "local", "custom", "adopted"):
+        value = layout.get(role)
+        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+            validator.fail(f"{path}: layout.{role} must be a list of strings")
+
+    adoption = contract.get("adoption")
+    if not isinstance(adoption, dict):
+        validator.fail(f"{path}: missing [adoption] table")
+    if adoption.get("hash_algorithm") != "sha256" or adoption.get("mode") != "review-gated":
+        validator.fail(f"{path}: adoption must use sha256 and review-gated mode")
+    ignored = adoption.get("ignore")
+    if not isinstance(ignored, list) or not all(isinstance(item, str) for item in ignored):
+        validator.fail(f"{path}: adoption.ignore must be a list of role names")
+
+    for source in layout["source_inputs"]:
+        if source.startswith(("~", "$")) or "*" in source:
+            continue
+        if not (REPO_ROOT / source).exists():
+            validator.fail(f"{path}: source input does not exist: {source}")
+
+    return path, contract
+
+
+def validate_compose_app(tool: str, parser: str) -> None:
+    path, contract = load_music_app(tool)
+    if contract.get("status") != "planned" or contract.get("strategy") != "compose":
+        validator.fail(f"{path}: {tool} must be a planned compose contract")
+    if contract.get("target_runtime_owner") != "configctl":
+        validator.fail(f"{path}: target_runtime_owner must be 'configctl'")
+    if contract.get("renderer_required") is not True:
+        validator.fail(f"{path}: renderer_required must be true")
+
+    composition = contract.get("composition")
+    if not isinstance(composition, dict):
+        validator.fail(f"{path}: missing [composition] table")
+    if composition.get("write_mode") != "atomic" or composition.get("dry_run_required") is not True:
+        validator.fail(f"{path}: composition must require atomic writes and dry-run")
+    if parser not in composition.get("requires_parser", []):
+        validator.fail(f"{path}: composition.requires_parser must include {parser!r}")
+
+
+def validate_music_apps() -> None:
+    path, mpd = load_music_app("mpd")
+    if mpd.get("status") != "active" or mpd.get("strategy") != "native-include":
+        validator.fail(f"{path}: MPD must be an active native-include contract")
+    if mpd.get("current_runtime_owner") != "home-manager":
+        validator.fail(f"{path}: current_runtime_owner must be 'home-manager'")
+    if mpd.get("target_runtime_owner") != "home-manager":
+        validator.fail(f"{path}: target_runtime_owner must remain 'home-manager'")
+    if mpd.get("renderer_required") is not False:
+        validator.fail(f"{path}: renderer_required must be false")
+    if mpd["layout"].get("runtime_includes") != ["custom.d/*.conf", "local.conf"]:
+        validator.fail(f"{path}: runtime_includes must load custom overrides then local.conf")
+
+    validate_compose_app("rmpc", "ron")
+    validate_compose_app("beets", "yaml")
+
+
 validator.validate_common = validate_common
-raise SystemExit(validator.main())
+legacy_result = validator.main()
+if legacy_result != 0:
+    raise SystemExit(legacy_result)
+validate_music_apps()
+print("validated managed-music configctl app contracts")
+raise SystemExit(0)

--- a/checks/verify-configctl-contracts.py
+++ b/checks/verify-configctl-contracts.py
@@ -52,6 +52,15 @@ def validate_common(
     return result
 
 
+def require_string_role(path: Path, layout: dict[str, Any], role: str, *, required: bool = True) -> list[str]:
+    value = layout.get(role)
+    if value is None and not required:
+        return []
+    if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+        validator.fail(f"{path}: layout.{role} must be a list of strings")
+    return value
+
+
 def load_music_app(tool: str) -> tuple[Path, dict[str, Any]]:
     path = APP_DIR / f"{tool}.toml"
     if not path.is_file():
@@ -81,9 +90,9 @@ def load_music_app(tool: str) -> tuple[Path, dict[str, Any]]:
         validator.fail(f"{path}: layout.standard must be 'configctl-v1'")
 
     for role in ("source_inputs", "local", "custom", "adopted"):
-        value = layout.get(role)
-        if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
-            validator.fail(f"{path}: layout.{role} must be a list of strings")
+        require_string_role(path, layout, role)
+    require_string_role(path, layout, "promoted_inputs", required=False)
+    require_string_role(path, layout, "auxiliary_outputs", required=False)
 
     adoption = contract.get("adoption")
     if not isinstance(adoption, dict):
@@ -100,10 +109,24 @@ def load_music_app(tool: str) -> tuple[Path, dict[str, Any]]:
         if not (REPO_ROOT / source).exists():
             validator.fail(f"{path}: source input does not exist: {source}")
 
+    for promoted in layout.get("promoted_inputs", []):
+        if not promoted.startswith(f"files/home/.config/{tool}/custom.d/dubnium/"):
+            validator.fail(
+                f"{path}: promoted_inputs must stay under the profile-scoped configctl promote destination"
+            )
+        if "*" not in promoted:
+            validator.fail(f"{path}: promoted_inputs must use a bounded fragment glob")
+
     return path, contract
 
 
-def validate_compose_app(tool: str, parser: str) -> None:
+def validate_compose_app(
+    tool: str,
+    parser: str,
+    *,
+    expected_promoted: str,
+    expected_source_order: list[str],
+) -> None:
     path, contract = load_music_app(tool)
     if contract.get("status") != "planned" or contract.get("strategy") != "compose":
         validator.fail(f"{path}: {tool} must be a planned compose contract")
@@ -112,6 +135,12 @@ def validate_compose_app(tool: str, parser: str) -> None:
     if contract.get("renderer_required") is not True:
         validator.fail(f"{path}: renderer_required must be true")
 
+    layout = contract["layout"]
+    if layout.get("promoted_inputs") != [expected_promoted]:
+        validator.fail(
+            f"{path}: promoted_inputs must exactly match configctl promote output {expected_promoted!r}"
+        )
+
     composition = contract.get("composition")
     if not isinstance(composition, dict):
         validator.fail(f"{path}: missing [composition] table")
@@ -119,6 +148,10 @@ def validate_compose_app(tool: str, parser: str) -> None:
         validator.fail(f"{path}: composition must require atomic writes and dry-run")
     if parser not in composition.get("requires_parser", []):
         validator.fail(f"{path}: composition.requires_parser must include {parser!r}")
+    if composition.get("source_order") != expected_source_order:
+        validator.fail(
+            f"{path}: source_order must preserve base/adopted, managed, promoted, local, then live custom precedence"
+        )
 
 
 def validate_music_apps() -> None:
@@ -142,8 +175,18 @@ def validate_music_apps() -> None:
             f"{path}: runtime_includes must load promoted profile, live custom, then local overrides"
         )
 
-    validate_compose_app("rmpc", "ron")
-    validate_compose_app("beets", "yaml")
+    validate_compose_app(
+        "rmpc",
+        "ron",
+        expected_promoted="files/home/.config/rmpc/custom.d/dubnium/*.ron",
+        expected_source_order=["source_inputs", "promoted_inputs", "local", "custom"],
+    )
+    validate_compose_app(
+        "beets",
+        "yaml",
+        expected_promoted="files/home/.config/beets/custom.d/dubnium/*.yaml",
+        expected_source_order=["adopted", "auxiliary_outputs", "promoted_inputs", "local", "custom"],
+    )
 
 
 validator.validate_common = validate_common

--- a/contracts/configctl/README.md
+++ b/contracts/configctl/README.md
@@ -60,7 +60,7 @@ App manifests and migration-oriented init manifests may declare lifecycle fields
 | Field | Meaning |
 | --- | --- |
 | `status` | `active` or `planned`. |
-| `current_runtime_owner` | Current writer of runtime outputs or mutable state, usually `home-manager` today. |
+| `current_runtime_owner` | Current writer of runtime outputs or mutable state, usually `home-manager` today. Pre-existing user-owned configs may state `user` during an adoption migration. |
 | `target_runtime_owner` | Intended future writer after migration. |
 | `executor_may_validate` | Whether `configctl` may validate the contract now. |
 | `executor_may_adopt` | Whether `configctl` may use the adoption policy now. |
@@ -69,7 +69,7 @@ App manifests and migration-oriented init manifests may declare lifecycle fields
 
 These lifecycle fields are policy metadata for ownership transitions; they are not required by the Dubnium v1 `configctl init` schema unless a typed contract or repo-side verifier requires them.
 
-Planned compose manifests are intentionally not write-enabled while Home Manager still owns the runtime files.
+Planned compose manifests are intentionally not write-enabled while another owner still owns the runtime files. That owner may be Home Manager or, for a pre-existing configuration being adopted, the user. A user-owned compose migration must remain review-gated and write-disabled until parser-aware adoption/composition is available.
 
 ## Manifest semantics
 
@@ -98,6 +98,9 @@ Important constraints:
 | Git | `apps/git.toml` | native include | active | Home Manager | Home Manager |
 | Hyprland | `apps/hypr.toml` | native include | active | Home Manager | Home Manager |
 | Zsh | `apps/zsh.toml` | native include | active | Home Manager | Home Manager |
+| MPD | `apps/mpd.toml` | native include | active | Home Manager | Home Manager |
+| rmpc | `apps/rmpc.toml` | compose | planned | Home Manager | configctl |
+| beets | `apps/beets.toml` | compose | planned | user | configctl |
 | Hyprpaper | `apps/hyprpaper.toml` | compose | planned | Home Manager | configctl |
 | Mako | `apps/mako.toml` | compose | planned | Home Manager | configctl |
 | Eww | `apps/eww.toml` | compose | planned | Home Manager | configctl |
@@ -107,6 +110,8 @@ Important constraints:
 | uv tools | `init/uv-tools.toml` | init | active | explicit user state | configctl init |
 | Variety | `init/variety.toml` | init | planned | Home Manager activation | configctl init |
 | Multi-agent worktrees skill | `init/multi-agent-worktrees.toml` | init | active, validate-only | dotfiles/manual copy | configctl init |
+
+For the managed-music workflow, MPD can use configctl immediately because MPD has native optional include support. rmpc and beets remain explicitly planned/write-disabled until Dubnium's existing composition engine supports their structured formats and ownership gates; see `ryjen/dubnium#693`.
 
 ### OBS presentation initialization
 
@@ -140,7 +145,7 @@ Or build the check derivation explicitly:
 nix build .#checks.x86_64-linux.configctl-contracts
 ```
 
-The verifier checks that init contracts are valid TOML, use supported risk labels, have unique IDs, and that enabled contracts have dotfiles-side validation rules. For `npm-globals`, `pip-globals`, and `uv-tools`, it also verifies that contract paths match the Home Manager-managed paths and that referenced package/tool manifests exist. For `obs-presentation`, it requires the reviewed executor paths and behavior, the non-destructive default risk, the exact Camera Overlay structure, and no `device_id` key anywhere in the versioned OBS collection.
+The verifier checks that init contracts are valid TOML, use supported risk labels, have unique IDs, and that enabled contracts have dotfiles-side validation rules. For `npm-globals`, `pip-globals`, and `uv-tools`, it also verifies that contract paths match the Home Manager-managed paths and that referenced package/tool manifests exist. For `obs-presentation`, it requires the reviewed executor paths and behavior, the non-destructive default risk, the exact Camera Overlay structure, and no `device_id` key anywhere in the versioned OBS collection. The extended verifier also checks the managed-music app contracts so MPD remains active/native-include and rmpc/beets remain parser-gated, planned, and write-disabled until their executor support is implemented.
 
 ## Non-goals
 

--- a/contracts/configctl/apps/README.md
+++ b/contracts/configctl/apps/README.md
@@ -1,0 +1,11 @@
+# App contracts
+
+Application contracts describe config ownership, layering, adoption, and composition policy consumed by Dubnium `configctl` workflows.
+
+Managed music coverage:
+
+- `mpd.toml`: active native-include layering; Home Manager owns the generated root config while configctl owns local/custom overrides.
+- `rmpc.toml`: planned RON composition; configctl is the target runtime owner after renderer support lands.
+- `beets.toml`: planned YAML adoption/composition from the existing user-owned config; configctl is the target runtime owner and writes remain disabled until safe composition is implemented.
+
+A planned compose contract may retain `current_runtime_owner = "user"` when adopting pre-existing user configuration. Such contracts must remain write-disabled until review-gated adoption and a parser-aware renderer are available.

--- a/contracts/configctl/apps/beets.toml
+++ b/contracts/configctl/apps/beets.toml
@@ -1,0 +1,57 @@
+schema_version = 1
+tool = "beets"
+owner = "dotfiles"
+profile = "dubnium"
+status = "planned"
+strategy = "compose"
+current_runtime_owner = "user"
+target_runtime_owner = "configctl"
+executor_may_validate = true
+executor_may_adopt = true
+executor_may_write_outputs = false
+renderer_required = true
+description = "The existing beets config remains user-owned today; configctl must adopt and compose it with the dotfiles MPD fragment without clobbering personal metadata/import settings."
+
+[layout]
+root = "~/.config/beets"
+standard = "configctl-v1"
+source_inputs = [
+  "modules/home/music-library.nix"
+]
+runtime_outputs = [
+  "config.yaml"
+]
+local = [
+  "local.yaml"
+]
+custom = [
+  "custom.d/*.yaml"
+]
+adopted = [
+  "adopted.d/*.yaml"
+]
+auxiliary_outputs = [
+  "dotfiles-mpd.yaml"
+]
+
+[composition]
+source_order = [
+  "source_inputs",
+  "local",
+  "custom"
+]
+output_role = "runtime_outputs"
+write_mode = "atomic"
+dry_run_required = true
+requires_parser = [
+  "yaml"
+]
+
+[adoption]
+state_path = "~/.local/state/configctl/adoptions/beets.toml"
+hash_algorithm = "sha256"
+mode = "review-gated"
+ignore = [
+  "local",
+  "adopted"
+]

--- a/contracts/configctl/apps/beets.toml
+++ b/contracts/configctl/apps/beets.toml
@@ -18,6 +18,9 @@ standard = "configctl-v1"
 source_inputs = [
   "modules/home/music-library.nix"
 ]
+promoted_inputs = [
+  "files/home/.config/beets/custom.d/dubnium/*.yaml"
+]
 runtime_outputs = [
   "config.yaml"
 ]
@@ -38,10 +41,11 @@ auxiliary_outputs = [
 # The adopted copy of the pre-existing user config is a deliberate composition
 # input for beets rather than a passive archive: preserving those settings is a
 # migration invariant. The Home Manager MPD fragment is layered on top, followed
-# by ordinary configctl local/custom overrides.
+# by reviewed profile-promoted fragments, then local/live custom overrides.
 source_order = [
   "adopted",
   "auxiliary_outputs",
+  "promoted_inputs",
   "local",
   "custom"
 ]

--- a/contracts/configctl/apps/beets.toml
+++ b/contracts/configctl/apps/beets.toml
@@ -35,8 +35,13 @@ auxiliary_outputs = [
 ]
 
 [composition]
+# The adopted copy of the pre-existing user config is a deliberate composition
+# input for beets rather than a passive archive: preserving those settings is a
+# migration invariant. The Home Manager MPD fragment is layered on top, followed
+# by ordinary configctl local/custom overrides.
 source_order = [
-  "source_inputs",
+  "adopted",
+  "auxiliary_outputs",
   "local",
   "custom"
 ]

--- a/contracts/configctl/apps/mpd.toml
+++ b/contracts/configctl/apps/mpd.toml
@@ -1,0 +1,51 @@
+schema_version = 1
+tool = "mpd"
+owner = "dotfiles"
+profile = "dubnium"
+status = "active"
+strategy = "native-include"
+current_runtime_owner = "home-manager"
+target_runtime_owner = "home-manager"
+executor_may_validate = true
+executor_may_adopt = true
+executor_may_write_outputs = false
+renderer_required = false
+description = "Home Manager owns MPD's generated root config; MPD native include_optional directives load configctl local and custom overrides."
+
+[layout]
+root = "~/.config/mpd"
+standard = "configctl-v1"
+source_inputs = [
+  "modules/home/music-library.nix"
+]
+local = [
+  "local.conf"
+]
+custom = [
+  "custom.d/*.conf"
+]
+adopted = [
+  "adopted.d/*.conf"
+]
+runtime_includes = [
+  "custom.d/*.conf",
+  "local.conf"
+]
+
+[adoption]
+state_path = "~/.local/state/configctl/adoptions/mpd.toml"
+hash_algorithm = "sha256"
+mode = "review-gated"
+ignore = [
+  "local",
+  "adopted"
+]
+
+[validation]
+must_not_manage = [
+  "local"
+]
+must_exist_or_be_creatable = [
+  "custom",
+  "adopted"
+]

--- a/contracts/configctl/apps/mpd.toml
+++ b/contracts/configctl/apps/mpd.toml
@@ -10,13 +10,14 @@ executor_may_validate = true
 executor_may_adopt = true
 executor_may_write_outputs = false
 renderer_required = false
-description = "Home Manager owns MPD's generated root config; MPD native include_optional directives load configctl local and custom overrides."
+description = "Home Manager owns MPD's generated root config; MPD native include_optional directives load configctl promoted, custom, and local overrides."
 
 [layout]
 root = "~/.config/mpd"
 standard = "configctl-v1"
 source_inputs = [
-  "modules/home/music-library.nix"
+  "modules/home/music-library.nix",
+  "files/home/.config/mpd/custom.d/dubnium/00-empty.conf"
 ]
 local = [
   "local.conf"
@@ -28,6 +29,7 @@ adopted = [
   "adopted.d/*.conf"
 ]
 runtime_includes = [
+  "custom.d/dubnium/*.conf",
   "custom.d/*.conf",
   "local.conf"
 ]

--- a/contracts/configctl/apps/rmpc.toml
+++ b/contracts/configctl/apps/rmpc.toml
@@ -1,0 +1,54 @@
+schema_version = 1
+tool = "rmpc"
+owner = "dotfiles"
+profile = "dubnium"
+status = "planned"
+strategy = "compose"
+current_runtime_owner = "home-manager"
+target_runtime_owner = "configctl"
+executor_may_validate = true
+executor_may_adopt = true
+executor_may_write_outputs = false
+renderer_required = true
+description = "rmpc has a single RON runtime config and needs configctl composition before output ownership can move from Home Manager."
+
+[layout]
+root = "~/.config/rmpc"
+standard = "configctl-v1"
+source_inputs = [
+  "files/home/.config/rmpc/base.ron"
+]
+runtime_outputs = [
+  "config.ron"
+]
+local = [
+  "local.ron"
+]
+custom = [
+  "custom.d/*.ron"
+]
+adopted = [
+  "adopted.d/*.ron"
+]
+
+[composition]
+source_order = [
+  "source_inputs",
+  "local",
+  "custom"
+]
+output_role = "runtime_outputs"
+write_mode = "atomic"
+dry_run_required = true
+requires_parser = [
+  "ron"
+]
+
+[adoption]
+state_path = "~/.local/state/configctl/adoptions/rmpc.toml"
+hash_algorithm = "sha256"
+mode = "review-gated"
+ignore = [
+  "local",
+  "adopted"
+]

--- a/contracts/configctl/apps/rmpc.toml
+++ b/contracts/configctl/apps/rmpc.toml
@@ -18,6 +18,9 @@ standard = "configctl-v1"
 source_inputs = [
   "files/home/.config/rmpc/base.ron"
 ]
+promoted_inputs = [
+  "files/home/.config/rmpc/custom.d/dubnium/*.ron"
+]
 runtime_outputs = [
   "config.ron"
 ]
@@ -34,6 +37,7 @@ adopted = [
 [composition]
 source_order = [
   "source_inputs",
+  "promoted_inputs",
   "local",
   "custom"
 ]

--- a/contracts/configctl/schema-v1.md
+++ b/contracts/configctl/schema-v1.md
@@ -250,10 +250,11 @@ Planned compose contracts must set:
 
 ```toml
 status = "planned"
-current_runtime_owner = "home-manager"
 target_runtime_owner = "configctl"
 executor_may_write_outputs = false
 ```
+
+`current_runtime_owner` must state the actual current writer. It is normally `home-manager`, but may be `user` when a pre-existing user-owned configuration is being migrated. A user-owned planned compose contract must remain review-gated and write-disabled until parser-aware adoption/composition can preserve the existing configuration safely.
 
 ## Adoption
 

--- a/contracts/configctl/schema-v1.md
+++ b/contracts/configctl/schema-v1.md
@@ -223,10 +223,11 @@ Common fields:
 | `root` | Runtime config directory for the tool. |
 | `standard` | Layout convention identifier, usually `configctl-v1`. |
 | `source_inputs` | Repo-owned modules, fragments, or static source files used to produce runtime configuration. |
+| `promoted_inputs` | Repo-owned, profile-scoped fragments created by `configctl promote`; compose contracts consume these explicitly so reviewed fragments survive rebuilds. |
 | `runtime_outputs` | Final files the app reads. |
 | `local` | Local-only unmanaged paths. |
-| `custom` | User-authored promotion candidates. |
-| `adopted` | Archive/evidence paths. |
+| `custom` | Live user-authored promotion candidates. |
+| `adopted` | Archive/evidence paths; a migration contract may also declare them as semantic composition inputs when preserving pre-existing user config. |
 | `runtime_includes` | Paths directly loaded by apps with native include support. |
 | `auxiliary_outputs` | Runtime helper files that are not composition outputs. |
 
@@ -234,17 +235,25 @@ All path role fields use arrays, even when they contain one item.
 
 `source_inputs` must describe source-of-truth inputs, not generated runtime outputs. Runtime outputs belong under `runtime_outputs` or `auxiliary_outputs`.
 
+`promoted_inputs` are repository-relative paths and must be bounded to the same profile-scoped destination used by `configctl promote`:
+
+```text
+files/home/.config/<tool>/custom.d/<profile>/*
+```
+
+They are distinct from live runtime `custom` fragments. A compose contract should normally order promoted inputs before local/live custom overrides, so reviewed repository state is reproducible while current local edits can still take precedence before promotion.
+
 ## Composition
 
 `[composition]` is required when `strategy = "compose"`.
 
 | Field | Meaning |
 | --- | --- |
-| `source_order` | Ordered layout role names used as composition inputs. |
+| `source_order` | Ordered layout role names used as composition inputs. May include `promoted_inputs` when profile-scoped promoted fragments are supported. |
 | `output_role` | Layout role name for rendered outputs. |
 | `write_mode` | Output write mode, currently `atomic`. |
 | `dry_run_required` | Must be true before output writing is enabled. |
-| `requires_parser` | Optional parser requirements such as `jsonc` or `css`. |
+| `requires_parser` | Optional parser requirements such as `jsonc`, `yaml`, or `ron`. |
 
 Planned compose contracts must set:
 
@@ -253,6 +262,8 @@ status = "planned"
 target_runtime_owner = "configctl"
 executor_may_write_outputs = false
 ```
+
+A compose contract must not become write-enabled by flipping only `executor_may_write_outputs`. Output ownership activation is an explicit lifecycle transition: the contract must be `active`, its target owner must be `configctl`, and `current_runtime_owner` must accurately reflect the handoff state enforced by the executor.
 
 `current_runtime_owner` must state the actual current writer. It is normally `home-manager`, but may be `user` when a pre-existing user-owned configuration is being migrated. A user-owned planned compose contract must remain review-gated and write-disabled until parser-aware adoption/composition can preserve the existing configuration safely.
 

--- a/docs/music-library.md
+++ b/docs/music-library.md
@@ -43,6 +43,28 @@ The module configures:
 - a **Music Library** desktop entry, available through the normal application launcher;
 - `$XDG_DATA_HOME/mpd/playlists` as the shared persisted playlist directory.
 
+## Configctl ownership
+
+The workflow is represented explicitly in the dotfiles configctl app-contract surface rather than bypassing configctl:
+
+- **MPD is active today as a `native-include` contract.** Home Manager owns the generated root MPD config, while MPD loads configctl-controlled `~/.config/mpd/custom.d/*.conf` and `~/.config/mpd/local.conf` through native `include_optional` directives. The local file loads last and therefore has the highest precedence.
+- **rmpc is a planned `compose` contract.** Its stable RON source lives at `files/home/.config/rmpc/base.ron`; configctl is the declared target runtime owner once RON composition is implemented. Home Manager remains the writer until then.
+- **beets is a planned `compose` contract.** The existing `config.yaml` remains user-owned until configctl can safely adopt and compose YAML without overwriting personal import/plugin settings. The generated `dotfiles-mpd.yaml` remains an auxiliary Home Manager output in the interim.
+
+The contracts deliberately keep `executor_may_write_outputs = false` for rmpc and beets until the corresponding configctl renderers exist. This prevents the policy surface from claiming capabilities the executor does not yet have.
+
+Once Dubnium recognizes the MPD layer definition, the normal configctl workflow is:
+
+```sh
+configctl status mpd
+configctl adopt mpd
+# edit ~/.config/mpd/custom.d/<name>.conf or ~/.config/mpd/local.conf
+configctl status mpd
+configctl promote mpd <name>.conf
+```
+
+`local.conf` is intentionally never promoted or Home Manager-owned. Use it for machine-local overrides; use `custom.d/*.conf` for reviewable promotion candidates.
+
 ## Playback controls
 
 `music-playerctl` provides deterministic MPRIS selection for the music widget and scripts:

--- a/docs/music-library.md
+++ b/docs/music-library.md
@@ -1,0 +1,94 @@
+# Managed music library
+
+The managed music workflow separates metadata ownership from playback state:
+
+```text
+beets -> tagged files -> MPD -> rmpc / MPRIS -> Waybar
+                     \
+                      -> mpv remains available for ad-hoc media and video
+```
+
+## Ownership
+
+- **beets** remains the canonical metadata and library-management authority.
+- **MPD** owns only its derived tag cache, current queue, playback state, and stored playlists.
+- **rmpc** is the interactive MPD library/queue/playlist client.
+- **mpv** remains the general-purpose player for video, URLs, and files outside the managed collection.
+
+Do not use an MPD client as a tag-writing authority. Metadata changes should continue to flow through beets and the tagged files.
+
+## Declarative configuration
+
+Enable the base music tooling and the MPD backend:
+
+```nix
+dotfiles.music = {
+  enable = true;
+  musicDirectory = "/path/to/Music";
+  mpd.enable = true;
+};
+```
+
+The Dubnium profile enables this against `/mnt/isotope/Music`.
+
+The module configures:
+
+- MPD as a Home Manager user service;
+- loopback-only MPD control on `127.0.0.1:6600`;
+- zeroconf disabled by default;
+- PipeWire output and ReplayGain auto mode;
+- MPD filesystem auto-update so beets-driven file/tag changes are picked up without requiring a second metadata authority;
+- `mpd-mpris` for `playerctl` and Waybar integration;
+- `rmpc` as the terminal library browser/controller;
+- a **Music Library** desktop entry, available through the normal application launcher;
+- `$XDG_DATA_HOME/mpd/playlists` as the shared persisted playlist directory.
+
+## Playback controls
+
+`music-playerctl` provides deterministic MPRIS selection for the music widget and scripts:
+
+1. `MUSIC_PLAYER` when explicitly set and available;
+2. playing MPD;
+3. playing mpv;
+4. paused MPD;
+5. paused mpv;
+6. stopped/available MPD;
+7. stopped/available mpv.
+
+This lets managed-library playback prefer MPD without preventing an actively playing ad-hoc mpv instance from being controlled when MPD is idle.
+
+Useful diagnostics:
+
+```sh
+systemctl --user status mpd mpd-mpris
+journalctl --user -u mpd -u mpd-mpris
+playerctl --player=mpd status
+rmpc
+```
+
+## Beets integration
+
+The repository intentionally does **not** take ownership of `~/.config/beets/config.yaml`; that file may contain personal import, path, metadata-source, and plugin settings that should not be replaced by Home Manager.
+
+Instead, Home Manager writes `~/.config/beets/dotfiles-mpd.yaml` with the MPD, playlist, and smart-playlist settings. To enable the deeper beets integration, merge the following into the existing beets configuration while preserving any existing plugins:
+
+```yaml
+include: dotfiles-mpd.yaml
+plugins: <existing plugins> mpdupdate playlist smartplaylist
+```
+
+If `include` or `plugins` already exists, extend the existing value rather than replacing it.
+
+The generated smart-playlist configuration includes `recently-added.m3u` for tracks added in the last four weeks. Regenerate smart playlists with:
+
+```sh
+beet splupdate
+```
+
+MPD/rmpc read generated and user-curated M3U playlists from the same playlist directory.
+
+The core MPD library does not depend on this optional plugin step: MPD's filesystem auto-update keeps its derived index current as beets changes tags or paths.
+
+## Safety boundary
+
+The existing `music-dislike` delete/trash workflow remains mpv-specific for now. Applying it blindly to MPD would mutate the filesystem without updating the canonical beets library database. Any managed-library deletion workflow should be implemented through beets first, then projected to MPD.

--- a/files/home/.config/mpd/custom.d/dubnium/00-empty.conf
+++ b/files/home/.config/mpd/custom.d/dubnium/00-empty.conf
@@ -1,0 +1,1 @@
+# Profile-scoped MPD fragments promoted by configctl live here.

--- a/files/home/.config/rmpc/base.ron
+++ b/files/home/.config/rmpc/base.ron
@@ -1,0 +1,16 @@
+(
+    address: "127.0.0.1:6600",
+    password: None,
+    theme: None,
+    cache_dir: None,
+    on_song_change: None,
+    volume_step: 5,
+    max_fps: 30,
+    scrolloff: 4,
+    wrap_navigation: false,
+    enable_mouse: true,
+    enable_config_hot_reload: true,
+    status_update_interval_ms: 1000,
+    select_current_song_on_change: true,
+    browser_song_sort: [Disc, Track, Artist, Title],
+)

--- a/files/home/.local/bin/music-playerctl
+++ b/files/home/.local/bin/music-playerctl
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+playerctl_bin="${PLAYERCTL_BIN:-playerctl}"
+
+status_of() {
+  "$playerctl_bin" --player="$1" status 2>/dev/null || true
+}
+
+select_player() {
+  local player status wanted
+
+  if [ -n "${MUSIC_PLAYER:-}" ] \
+    && "$playerctl_bin" --player="$MUSIC_PLAYER" status >/dev/null 2>&1; then
+    printf '%s\n' "$MUSIC_PLAYER"
+    return 0
+  fi
+
+  # Prefer an actively playing source. If both are active, MPD wins because it
+  # is the managed-library backend. A playing mpv still wins over paused MPD.
+  for wanted in Playing Paused; do
+    for player in mpd mpv; do
+      status="$(status_of "$player")"
+      if [ "$status" = "$wanted" ]; then
+        printf '%s\n' "$player"
+        return 0
+      fi
+    done
+  done
+
+  # Finally prefer an available stopped MPD instance, then mpv. This allows a
+  # Waybar play action to resume the persistent MPD queue after login/restart.
+  for player in mpd mpv; do
+    if "$playerctl_bin" --player="$player" status >/dev/null 2>&1; then
+      printf '%s\n' "$player"
+      return 0
+    fi
+  done
+
+  return 1
+}
+
+if [ "${1:-}" = "--player-name" ]; then
+  select_player
+  exit $?
+fi
+
+player="$(select_player)" || {
+  printf 'music-playerctl: no MPD or mpv MPRIS player is available\n' >&2
+  exit 1
+}
+
+exec "$playerctl_bin" --player="$player" "$@"

--- a/files/home/.local/bin/music-retag-current
+++ b/files/home/.local/bin/music-retag-current
@@ -9,10 +9,21 @@ notify() {
   fi
 }
 
-uri="$(playerctl --player=mpv metadata xesam:url 2>/dev/null || true)"
+music_playerctl="${MUSIC_PLAYERCTL:-$HOME/.local/bin/music-playerctl}"
+player="mpv"
+
+if [ -x "$music_playerctl" ]; then
+  player="$($music_playerctl --player-name 2>/dev/null || true)"
+  if [ -z "$player" ]; then
+    notify "No MPD or mpv track found"
+    exit 1
+  fi
+fi
+
+uri="$(playerctl --player="$player" metadata xesam:url 2>/dev/null || true)"
 
 if [ -z "$uri" ]; then
-  notify "No mpv track URL found"
+  notify "No local track URL found for $player"
   exit 1
 fi
 

--- a/files/home/.local/bin/music-retag-current
+++ b/files/home/.local/bin/music-retag-current
@@ -9,6 +9,12 @@ notify() {
   fi
 }
 
+if [ -r "$HOME/.local/share/dubnium/music-env" ]; then
+  # GUI launchers may not inherit Home Manager session variables.
+  . "$HOME/.local/share/dubnium/music-env"
+fi
+
+music_dir="${DUBNIUM_MUSIC_DIR:-$HOME/Music}"
 music_playerctl="${MUSIC_PLAYERCTL:-$HOME/.local/bin/music-playerctl}"
 player="mpv"
 
@@ -23,28 +29,48 @@ fi
 uri="$(playerctl --player="$player" metadata xesam:url 2>/dev/null || true)"
 
 if [ -z "$uri" ]; then
-  notify "No local track URL found for $player"
+  notify "No local track path found for $player"
   exit 1
 fi
 
-case "$uri" in
-  file://*) ;;
-  *)
-    notify "Refusing non-local track"
-    exit 1
-    ;;
-esac
-
-path="$(python3 - "$uri" <<'PY'
+path="$(python3 - "$player" "$uri" "$music_dir" <<'PY'
 import sys
+from pathlib import Path
 from urllib.parse import unquote, urlparse
 
-parsed = urlparse(sys.argv[1])
-if parsed.scheme != "file":
+player, raw, music_root = sys.argv[1:4]
+
+if raw.startswith("file://"):
+    parsed = urlparse(raw)
+    if parsed.scheme != "file":
+        raise SystemExit(1)
+    candidate = Path(unquote(parsed.path))
+elif player == "mpd":
+    # mpd-mpris exposes MPD's database path directly. For a local MPD library
+    # this is normally relative to music_directory, not a file:// URI.
+    if "://" in raw:
+        raise SystemExit(1)
+    candidate = Path(raw)
+    if not candidate.is_absolute():
+        candidate = Path(music_root) / candidate
+else:
     raise SystemExit(1)
-print(unquote(parsed.path))
+
+candidate = candidate.expanduser().resolve()
+
+if player == "mpd":
+    root = Path(music_root).expanduser().resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        raise SystemExit(1)
+
+print(candidate)
 PY
-)"
+)" || {
+  notify "Could not resolve current $player track under the music library"
+  exit 1
+}
 
 if [ ! -f "$path" ]; then
   notify "Current track is not a file: $path"

--- a/files/home/.local/bin/music-status
+++ b/files/home/.local/bin/music-status
@@ -54,6 +54,8 @@ else:
     parsed = urlparse(url)
     if parsed.scheme == "file":
         full_text = os.path.basename(unquote(parsed.path)) or f"{player} music"
+    elif player == "mpd" and url:
+        full_text = os.path.basename(url.rstrip("/")) or "mpd music"
     else:
         full_text = f"{player} music"
 

--- a/files/home/.local/bin/music-status
+++ b/files/home/.local/bin/music-status
@@ -1,36 +1,46 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-status="$(playerctl --player=mpv status 2>/dev/null || true)"
+music_playerctl="${MUSIC_PLAYERCTL:-$HOME/.local/bin/music-playerctl}"
+player=""
 
-if [ -z "$status" ]; then
+if [ -x "$music_playerctl" ]; then
+  player="$($music_playerctl --player-name 2>/dev/null || true)"
+fi
+
+if [ -z "$player" ] && playerctl --player=mpv status >/dev/null 2>&1; then
+  player="mpv"
+fi
+
+if [ -z "$player" ]; then
   python3 - <<'PY'
 import json
 print(json.dumps({
     "text": "■ stopped",
     "alt": "stopped",
     "class": "stopped",
-    "tooltip": "MPV music is stopped\nLeft click to start playback",
+    "tooltip": "Music is stopped\nOpen Music Library to choose a track",
 }))
 PY
   exit 0
 fi
 
-artist="$(playerctl --player=mpv metadata xesam:artist 2>/dev/null || true)"
-title="$(playerctl --player=mpv metadata xesam:title 2>/dev/null || true)"
-album="$(playerctl --player=mpv metadata xesam:album 2>/dev/null || true)"
-url="$(playerctl --player=mpv metadata xesam:url 2>/dev/null || true)"
-position="$(playerctl --player=mpv position 2>/dev/null || true)"
-length_us="$(playerctl --player=mpv metadata mpris:length 2>/dev/null || true)"
+status="$(playerctl --player="$player" status 2>/dev/null || true)"
+artist="$(playerctl --player="$player" metadata xesam:artist 2>/dev/null || true)"
+title="$(playerctl --player="$player" metadata xesam:title 2>/dev/null || true)"
+album="$(playerctl --player="$player" metadata xesam:album 2>/dev/null || true)"
+url="$(playerctl --player="$player" metadata xesam:url 2>/dev/null || true)"
+position="$(playerctl --player="$player" position 2>/dev/null || true)"
+length_us="$(playerctl --player="$player" metadata mpris:length 2>/dev/null || true)"
 
-python3 - "$status" "$artist" "$title" "$album" "$url" "$position" "$length_us" <<'PY'
+python3 - "$player" "$status" "$artist" "$title" "$album" "$url" "$position" "$length_us" <<'PY'
 import json
 import os
 import sys
 import time
 from urllib.parse import unquote, urlparse
 
-status, artist, title, album, url, position_raw, length_us_raw = sys.argv[1:8]
+player, status, artist, title, album, url, position_raw, length_us_raw = sys.argv[1:9]
 status = status.strip()
 artist = artist.strip()
 title = title.strip()
@@ -43,9 +53,9 @@ elif title:
 else:
     parsed = urlparse(url)
     if parsed.scheme == "file":
-        full_text = os.path.basename(unquote(parsed.path)) or "mpv music"
+        full_text = os.path.basename(unquote(parsed.path)) or f"{player} music"
     else:
-        full_text = "mpv music"
+        full_text = f"{player} music"
 
 icon = {
     "Playing": "▶",
@@ -83,6 +93,7 @@ length_us = parse_float(length_us_raw)
 length = length_us / 1_000_000 if length_us is not None else None
 
 metadata_lines = [
+    f"Player: {player}",
     f"Status: {status}",
     f"Track: {title or full_text}",
 ]

--- a/files/home/.local/bin/music-toggle
+++ b/files/home/.local/bin/music-toggle
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+music_playerctl="${MUSIC_PLAYERCTL:-$HOME/.local/bin/music-playerctl}"
+
+if [ -x "$music_playerctl" ] && "$music_playerctl" status >/dev/null 2>&1; then
+  exec "$music_playerctl" play-pause
+fi
+
+# Compatibility fallback for profiles that do not enable the managed MPD
+# workflow and therefore do not install music-playerctl.
 if playerctl --player=mpv status >/dev/null 2>&1; then
   exec playerctl --player=mpv play-pause
 fi

--- a/home/ryjen/profiles/dubnium.nix
+++ b/home/ryjen/profiles/dubnium.nix
@@ -21,5 +21,6 @@
   dotfiles.music = {
     enable = lib.mkDefault true;
     musicDirectory = lib.mkDefault "/mnt/isotope/Music";
+    mpd.enable = lib.mkDefault true;
   };
 }

--- a/home/ryjen/user.example.nix
+++ b/home/ryjen/user.example.nix
@@ -55,6 +55,7 @@
 
   # dotfiles.music.enable = false;
   # dotfiles.music.musicDirectory = "${config.home.homeDirectory}/Music";
+  # dotfiles.music.mpd.enable = false;
   # dotfiles.grimblast.enable = false;
   # dotfiles.graphical.keyring.enable = false;
   # dotfiles.idle.enable = false;

--- a/modules/home/default.nix
+++ b/modules/home/default.nix
@@ -33,6 +33,7 @@
     ./meeting.nix
     ./mise.nix
     ./music.nix
+    ./music-library.nix
     ./neovim.nix
     ./npm.nix
     ./office.nix

--- a/modules/home/music-library.nix
+++ b/modules/home/music-library.nix
@@ -9,6 +9,9 @@ let
   musicCfg = config.dotfiles.music;
   playlistDirectory = "${config.xdg.dataHome}/mpd/playlists";
   rmpcConfig = builtins.readFile ../../files/home/.config/rmpc/base.ron;
+  mpdCustomProfilesRoot = ../../files/home/.config/mpd/custom.d;
+  mpdCustomProfile = mpdCustomProfilesRoot + "/${config.dotfiles.host.name}";
+  hasMpdCustomProfile = builtins.pathExists mpdCustomProfile;
 in
 {
   options.dotfiles.music.mpd.enable = lib.mkEnableOption "MPD-backed managed music-library playback";
@@ -46,9 +49,11 @@ in
           name "PipeWire"
         }
 
-        # MPD supports native optional includes. Keep Home Manager authoritative
-        # for the root config while configctl owns review-gated local/custom
-        # override layers. Local is loaded last so it has highest precedence.
+        # MPD supports native optional includes. Home Manager owns the root
+        # config and materializes promoted, profile-scoped configctl fragments.
+        # Unpromoted custom fragments override the promoted profile layer, and
+        # local.conf remains machine-local with highest precedence.
+        include_optional "${config.xdg.configHome}/mpd/custom.d/${config.dotfiles.host.name}/*.conf"
         include_optional "${config.xdg.configHome}/mpd/custom.d/*.conf"
         include_optional "${config.xdg.configHome}/mpd/local.conf"
       '';
@@ -64,23 +69,34 @@ in
       config = rmpcConfig;
     };
 
-    # Keep the main beets config user-owned. This drop-in can be included from
-    # ~/.config/beets/config.yaml without Home Manager replacing that file.
-    xdg.configFile."beets/dotfiles-mpd.yaml".text = ''
-      mpd:
-        host: 127.0.0.1
-        port: 6600
-      playlist:
-        auto: true
-        playlist_dir: ${builtins.toJSON playlistDirectory}
-        relative_to: ${builtins.toJSON musicCfg.musicDirectory}
-      smartplaylist:
-        playlist_dir: ${builtins.toJSON playlistDirectory}
-        relative_to: ${builtins.toJSON musicCfg.musicDirectory}
-        playlists:
-          - name: recently-added.m3u
-            query: "added:-4w.."
-    '';
+    xdg.configFile = {
+      # Keep the main beets config user-owned. This drop-in can be included
+      # from ~/.config/beets/config.yaml without replacing that file.
+      "beets/dotfiles-mpd.yaml".text = ''
+        mpd:
+          host: 127.0.0.1
+          port: 6600
+        playlist:
+          auto: true
+          playlist_dir: ${builtins.toJSON playlistDirectory}
+          relative_to: ${builtins.toJSON musicCfg.musicDirectory}
+        smartplaylist:
+          playlist_dir: ${builtins.toJSON playlistDirectory}
+          relative_to: ${builtins.toJSON musicCfg.musicDirectory}
+          playlists:
+            - name: recently-added.m3u
+              query: "added:-4w.."
+      '';
+    }
+    // lib.optionalAttrs hasMpdCustomProfile {
+      # configctl promote stores reviewed fragments under
+      # files/home/.config/mpd/custom.d/<profile>/. Project that profile back
+      # into the runtime tree without taking ownership of root custom.d/*.conf.
+      "mpd/custom.d/${config.dotfiles.host.name}" = {
+        source = mpdCustomProfile;
+        recursive = true;
+      };
+    };
 
     xdg.desktopEntries.music-library = {
       name = "Music Library";

--- a/modules/home/music-library.nix
+++ b/modules/home/music-library.nix
@@ -1,0 +1,114 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.dotfiles.music.mpd;
+  musicCfg = config.dotfiles.music;
+  playlistDirectory = "${config.xdg.dataHome}/mpd/playlists";
+in
+{
+  options.dotfiles.music.mpd.enable = lib.mkEnableOption "MPD-backed managed music-library playback";
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = musicCfg.enable;
+        message = "dotfiles.music.mpd.enable requires dotfiles.music.enable";
+      }
+    ];
+
+    services.mpd = {
+      enable = true;
+      musicDirectory = musicCfg.musicDirectory;
+      playlistDirectory = playlistDirectory;
+      network = {
+        listenAddress = "127.0.0.1";
+        port = 6600;
+      };
+      extraConfig = ''
+        # The tagged filesystem remains a projection of the beets library.
+        # Watch it directly so MPD stays current even before the optional
+        # beets mpdupdate plugin is enabled in the user-owned beets config.
+        auto_update "yes"
+
+        # Keep the MPD control plane local by default. Remote access should be
+        # an explicit capability rather than an accidental LAN service.
+        zeroconf_enabled "no"
+
+        replaygain "auto"
+
+        audio_output {
+          type "pipewire"
+          name "PipeWire"
+        }
+      '';
+    };
+
+    services.mpd-mpris = {
+      enable = true;
+      mpd.useLocal = true;
+    };
+
+    programs.rmpc = {
+      enable = true;
+      config = ''
+        (
+            address: "127.0.0.1:6600",
+            password: None,
+            theme: None,
+            cache_dir: None,
+            on_song_change: None,
+            volume_step: 5,
+            max_fps: 30,
+            scrolloff: 4,
+            wrap_navigation: false,
+            enable_mouse: true,
+            enable_config_hot_reload: true,
+            status_update_interval_ms: 1000,
+            select_current_song_on_change: true,
+            browser_song_sort: [Disc, Track, Artist, Title],
+        )
+      '';
+    };
+
+    # Keep the main beets config user-owned. This drop-in can be included from
+    # ~/.config/beets/config.yaml without Home Manager replacing that file.
+    xdg.configFile."beets/dotfiles-mpd.yaml".text = ''
+      mpd:
+        host: 127.0.0.1
+        port: 6600
+      playlist:
+        auto: true
+        playlist_dir: ${builtins.toJSON playlistDirectory}
+        relative_to: ${builtins.toJSON musicCfg.musicDirectory}
+      smartplaylist:
+        playlist_dir: ${builtins.toJSON playlistDirectory}
+        relative_to: ${builtins.toJSON musicCfg.musicDirectory}
+        playlists:
+          - name: recently-added.m3u
+            query: "added:-4w.."
+    '';
+
+    xdg.desktopEntries.music-library = {
+      name = "Music Library";
+      genericName = "Music Library";
+      comment = "Browse and control the managed music library with rmpc";
+      exec = "${pkgs.alacritty}/bin/alacritty --title \"Music Library\" -e ${pkgs.rmpc}/bin/rmpc";
+      terminal = false;
+      categories = [
+        "Audio"
+        "AudioVideo"
+        "Music"
+        "Player"
+      ];
+    };
+
+    home.file.".local/bin/music-playerctl" = {
+      source = ../../files/home/.local/bin/music-playerctl;
+      executable = true;
+    };
+  };
+}

--- a/modules/home/music-library.nix
+++ b/modules/home/music-library.nix
@@ -8,6 +8,7 @@ let
   cfg = config.dotfiles.music.mpd;
   musicCfg = config.dotfiles.music;
   playlistDirectory = "${config.xdg.dataHome}/mpd/playlists";
+  rmpcConfig = builtins.readFile ../../files/home/.config/rmpc/base.ron;
 in
 {
   options.dotfiles.music.mpd.enable = lib.mkEnableOption "MPD-backed managed music-library playback";
@@ -44,6 +45,12 @@ in
           type "pipewire"
           name "PipeWire"
         }
+
+        # MPD supports native optional includes. Keep Home Manager authoritative
+        # for the root config while configctl owns review-gated local/custom
+        # override layers. Local is loaded last so it has highest precedence.
+        include_optional "${config.xdg.configHome}/mpd/custom.d/*.conf"
+        include_optional "${config.xdg.configHome}/mpd/local.conf"
       '';
     };
 
@@ -54,24 +61,7 @@ in
 
     programs.rmpc = {
       enable = true;
-      config = ''
-        (
-            address: "127.0.0.1:6600",
-            password: None,
-            theme: None,
-            cache_dir: None,
-            on_song_change: None,
-            volume_step: 5,
-            max_fps: 30,
-            scrolloff: 4,
-            wrap_navigation: false,
-            enable_mouse: true,
-            enable_config_hot_reload: true,
-            status_update_interval_ms: 1000,
-            select_current_song_on_change: true,
-            browser_song_sort: [Disc, Track, Artist, Title],
-        )
-      '';
+      config = rmpcConfig;
     };
 
     # Keep the main beets config user-owned. This drop-in can be included from

--- a/modules/home/waybar.nix
+++ b/modules/home/waybar.nix
@@ -20,11 +20,19 @@ let
       ];
   presentationOnlyOutput =
     if presentationOutput == null then "DUBNIUM/NO-PRESENTATION-OUTPUT" else presentationOutput;
-  renderedConfig =
+  renderedOutputConfig =
     builtins.replaceStrings
       [ "__DUBNIUM_NORMAL_OUTPUTS__" "__DUBNIUM_PRESENTATION_OUTPUT__" ]
       [ (builtins.toJSON normalOutputs) (builtins.toJSON presentationOnlyOutput) ]
       (builtins.readFile templates.${cfg.variant});
+  renderedConfig =
+    if config.dotfiles.music.mpd.enable then
+      builtins.replaceStrings
+        [ "playerctl --player=mpv" ]
+        [ "${config.home.homeDirectory}/.local/bin/music-playerctl" ]
+        renderedOutputConfig
+    else
+      renderedOutputConfig;
 in
 {
   options.dotfiles.waybar.variant = lib.mkOption {


### PR DESCRIPTION
## Summary

Implements the core of #164 with a declarative MPD + rmpc managed-library workflow while preserving beets as metadata authority and mpv for ad-hoc/video playback.

## What changed

- add a focused `music-library.nix` Home Manager module
- enable MPD only for the Dubnium profile
- bind MPD to loopback, disable zeroconf, enable PipeWire output, ReplayGain, and filesystem auto-update
- add `mpd-mpris` and `rmpc`
- add a **Music Library** desktop entry for the existing application launcher
- add `music-playerctl` with deterministic MPD/mpv MPRIS selection
- route Waybar music controls through that selector when MPD is enabled
- make music status/toggle/retag work with MPD as well as mpv
- add explicit configctl ownership contracts for MPD, rmpc, and beets

## Configctl ownership

### MPD — active native include

MPD supports native `include_optional`, so Home Manager continues to own the generated root config while configctl owns the mutable override workflow.

Runtime precedence is:

```text
~/.config/mpd/custom.d/dubnium/*.conf   # reviewed/profile-scoped promoted fragments
~/.config/mpd/custom.d/*.conf           # live promotion candidates
~/.config/mpd/local.conf                # machine-local, highest precedence
```

`configctl promote mpd <fragment.conf>` stages the live custom fragment under `files/home/.config/mpd/custom.d/<profile>/`. Home Manager projects the active `dotfiles.host.name` profile back into the runtime tree, closing the promote -> repo -> rebuild -> runtime loop without taking ownership of live `custom.d/*.conf` or `local.conf`.

Dubnium PR #694 registers MPD's `ToolLayers("local.conf", "custom.d", "adopted.d")`, enabling the existing `configctl status/adopt/promote mpd` workflows. The matching regression is exercised through the existing configctl CI path.

### rmpc — planned composition

rmpc has a single RON runtime config and no equivalent native include layer. Its stable base lives at `files/home/.config/rmpc/base.ron`. The app contract targets configctl ownership but remains `planned` and write-disabled until parser-aware RON composition is implemented.

### beets — planned safe adoption/composition

The existing `~/.config/beets/config.yaml` remains user-owned. Its planned contract is review-gated and write-disabled. The composition model explicitly includes the adopted copy of the pre-existing user configuration plus the Home Manager-generated `dotfiles-mpd.yaml` fragment, so a future ownership migration must preserve personal import/plugin/metadata settings instead of replacing them.

Dubnium issue #693 tracks extending the existing configctl composition engine for RON/YAML, bridging the dotfiles app-policy lifecycle/write gates, dry-run/diff, review-gated adoption, and atomic publication. rmpc/beets must remain planned/write-disabled until that executor support is proven.

## Beets runtime boundary

Until #693 lands, Home Manager only writes `~/.config/beets/dotfiles-mpd.yaml`. The existing beets config may opt into it while preserving existing plugins:

```yaml
include: dotfiles-mpd.yaml
plugins: <existing plugins> mpdupdate playlist smartplaylist
```

MPD filesystem `auto_update` keeps its derived index current even without those optional plugins, so playback does not make MPD a metadata authority.

`music-dislike` remains mpv-only intentionally; a managed-library deletion workflow must go through beets before projecting changes to MPD.

## Validation

- mocked `music-playerctl` routing tests cover playing/paused/stopped MPD and mpv plus explicit override behavior
- `bash -n` coverage for the modified music scripts
- configctl contract validation enforces MPD's promoted/live/local precedence and keeps rmpc/beets planned and write-disabled
- user option catalog and Ops Cadence checks are green on the current branch; full Nix/Home Manager CI remains the declarative gate

## Host impact

Dubnium gains `mpd.service` and `mpd-mpris.service` as user services and an MPD tag cache for `/mnt/isotope/Music`. MPD remains loopback-only by default; no LAN listener or secrets are introduced.

Refs #164
Refs ryjen/dubnium#693
Refs ryjen/dubnium#694