### PR TITLE
feat(unreal): add opt-in Unreal Editor support

### DIFF
--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        check: ${{ fromJSON(needs.discover-checks.outputs.checks) }}
+        check: ${{ fromJSON(needs.discover.outputs.checks) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -132,6 +132,9 @@ jobs:
 
       - name: Validate Flake Metadata
         run: nix flake metadata --no-write-lock-file
+
+      - name: Evaluate Enabled Unreal Configuration
+        run: nix eval '.#homeConfigurations."ryjen@unreal-verify".activationPackage.drvPath' --raw
 
       - name: Build OpenWork Package
         run: nix build .#openwork --print-build-logs

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -133,8 +133,11 @@ jobs:
       - name: Validate Flake Metadata
         run: nix flake metadata --no-write-lock-file
 
-      - name: Evaluate Enabled Unreal Configuration
-        run: nix eval '.#homeConfigurations."ryjen@unreal-verify".activationPackage.drvPath' --raw
+      - name: Build Enabled Unreal Configuration
+        run: |
+          nix build '.#homeConfigurations."ryjen@unreal-verify".activationPackage' \
+            --no-link \
+            --print-build-logs
 
       - name: Build OpenWork Package
         run: nix build .#openwork --print-build-logs

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        check: ${{ fromJSON(needs.discover.outputs.checks) }}
+        check: ${{ fromJSON(needs.discover-checks.outputs.checks) }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/docs/optional-tools.md
+++ b/docs/optional-tools.md
@@ -12,6 +12,47 @@ dotfiles.grimblast.enable = true;
 
 The module installs `pkgs.grimblast` into the user environment.
 
+## Unreal Editor
+
+Unreal Editor support is intentionally disabled by default. Enable the launcher,
+installer helper, and desktop entry with:
+
+```nix
+dotfiles.unreal.enable = true;
+```
+
+The Unreal Engine payload itself is not committed to dotfiles or copied into the
+Nix store. Epic's Linux installed builds require an authenticated Epic Games
+download and are large mutable archives. After enabling the module, download the
+Linux installed-build ZIP from Epic and install it with:
+
+```bash
+unreal-install ~/Downloads/Linux_Unreal_Engine_5.8.zip
+```
+
+By default the archive is extracted to `$XDG_DATA_HOME/unreal-engine`. The helper
+refuses to replace an existing installation and validates that the archive
+contains `Engine/Binaries/Linux/UnrealEditor` before publishing the directory.
+To keep multiple versions, choose a distinct root in local Home Manager config:
+
+```nix
+dotfiles.unreal = {
+  enable = true;
+  engineRoot = "/mnt/isotope/Unreal/5.8";
+};
+```
+
+Launch the editor from the desktop entry or with:
+
+```bash
+unreal-editor
+```
+
+The launcher exports `UE_ROOT` and runs the external Epic binary through
+`steam-run`, providing an FHS-compatible runtime for NixOS without making the
+engine payload part of the system closure. Project files and engine-generated
+state remain normal mutable user data.
+
 ## OpenWork
 
 Install the OpenWork desktop application with:

--- a/docs/optional-tools.md
+++ b/docs/optional-tools.md
@@ -73,8 +73,9 @@ dubnium.unreal.storage.enable = true;
 
 Enabling the module does **not** create or format an image. It adds the guarded
 `unreal-storage-init` helper and an ext4 loop mount at `/srv/unreal` using
-`loop,noatime,nofail,x-systemd.automount`. The mount declares `/mnt/isotope` as a
-dependency when that filesystem is managed by NixOS.
+`loop,noatime,nodev,nosuid,nofail,x-systemd.automount`. The mount declares
+`/mnt/isotope` as a dependency path; NixOS resolves whichever configured
+filesystem is responsible for that path before attempting the loop mount.
 
 After switching to the configuration, explicitly create an image of the desired
 logical capacity:
@@ -87,13 +88,18 @@ The initializer:
 
 - refuses to run unless `/mnt/isotope` is an actual mounted filesystem, avoiding
   accidental creation of a huge image on the root filesystem;
-- refuses to replace an existing image;
+- refuses to replace an existing image and uses a no-clobber creation step to
+  protect against a concurrent path appearing after the initial check;
+- validates that the resolved image parent remains beneath the resolved backing
+  mount before creating the image;
 - creates and formats only `/mnt/isotope/Unreal/unreal.ext4`;
-- rejects a requested logical size larger than the backing filesystem's current
-  available space;
-- temporarily loop-mounts the new ext4 filesystem to establish user ownership
-  and the `Engine`, `Projects`, and `Toolchains` directories;
-- removes a newly created image if initialization fails before completion;
+- rejects a requested logical size larger than the backing filesystem's
+  pre-creation available space;
+- temporarily loop-mounts the new ext4 filesystem with `nodev,nosuid` to
+  establish user ownership and the `Engine`, `Projects`, and `Toolchains`
+  directories;
+- removes a newly created image if initialization fails and the temporary mount
+  can be safely unmounted, but preserves the image if emergency unmount fails;
 - warns when the backing filesystem is `ntfs3` without its `sparse` mount option;
 - reports the image's actual allocated size with `du` after initialization.
 

--- a/docs/optional-tools.md
+++ b/docs/optional-tools.md
@@ -23,27 +23,32 @@ dotfiles.unreal.enable = true;
 
 The Unreal Engine payload itself is not committed to dotfiles or copied into the
 Nix store. Epic's Linux installed builds require an authenticated Epic Games
-download and are large mutable archives. After enabling the module, download the
-Linux installed-build ZIP from Epic and install it with:
+download. After enabling the module, download the Linux installed-build ZIP from
+Epic and install it with:
 
 ```bash
 unreal-install ~/Downloads/Linux_Unreal_Engine_5.8.zip
 ```
 
-The portable module default is `$XDG_DATA_HOME/unreal-engine`. The Dubnium
-profile overrides only the destination to `/mnt/isotope/Unreal/5.8` so the large
-mutable engine tree stays off the root filesystem; it does not enable Unreal.
-The helper refuses to replace an existing installation and validates that the
-archive contains `Engine/Binaries/Linux/UnrealEditor` before publishing the
-directory. To keep multiple versions on another profile, choose a distinct root
-in local Home Manager config:
+The portable engine default is `$XDG_DATA_HOME/unreal-engine`. Choose another
+absolute path when the engine should live on a larger native Linux filesystem:
 
 ```nix
 dotfiles.unreal = {
   enable = true;
-  engineRoot = "/path/to/Unreal/5.8";
+  engineRoot = "/data/unreal/5.8";
+  cacheRoot = "/data/cache/unreal-engine";
 };
 ```
+
+Prefer a native Linux filesystem for `engineRoot`. A Linux Unreal installation
+contains executable toolchains and expects normal POSIX path, permission,
+symlink, and case semantics. Do not make NTFS, exFAT, VFAT, CIFS, or another
+non-POSIX filesystem the default without validating the actual mount semantics.
+
+The installer refuses to replace an existing engine and validates that the
+archive contains `Engine/Binaries/Linux/UnrealEditor` before publishing the
+staged directory.
 
 Launch the editor from the desktop entry or with:
 
@@ -53,8 +58,33 @@ unreal-editor
 
 The launcher exports `UE_ROOT` and runs the external Epic binary through the
 free `steam-run` FHS runtime, providing NixOS compatibility without making the
-engine payload or Steam client part of the system closure. Project files and
-engine-generated state remain normal mutable user data.
+engine payload or Steam client part of the system closure.
+
+Epic's Installed Build deployment model is intentionally compatible with a
+read-only engine distribution. The wrapper therefore keeps Zen/DDC mutation in
+a separate writable cache root, defaulting to
+`$XDG_CACHE_HOME/unreal-engine/zen`. The engine directory can be treated as
+immutable after installation as long as workflows that intentionally modify the
+engine are handled separately.
+
+The important write boundaries are:
+
+- Projects must stay writable. Unreal writes project content and configuration,
+  plus generated `Saved`, `Intermediate`, `Binaries`, shader, cooking, autosave,
+  and log state.
+- Engine-level plugin installation writes under `Engine/Plugins` and therefore
+  conflicts with a sealed read-only engine tree. Prefer project-local plugins
+  under `<Project>/Plugins` when possible, or deliberately unseal/install/reseal
+  an engine version.
+- C++ development requires Epic's supported Linux clang/native toolchain in
+  addition to this editor wrapper. `SetupToolchain.sh` is a separate setup step
+  and may need writable engine/toolchain storage while it runs.
+- Fab project content can be imported into a writable project. Fab's documented
+  launcher-based `Install to Engine` plugin workflow is Windows/macOS-oriented,
+  so Linux engine-plugin installation is less integrated.
+- Engine updates are deliberately side-by-side/manual: download a new installed
+  build and point `engineRoot` at it rather than mutating an existing version in
+  place.
 
 ## OpenWork
 

--- a/docs/optional-tools.md
+++ b/docs/optional-tools.md
@@ -64,7 +64,14 @@ filesystem image:
 └── Toolchains/
 ```
 
-The NixOS storage support is also disabled by default. Enable its mount contract
+The NixOS storage support is also disabled by default. When dotfiles is consumed
+as a flake input, import the exported module into the host's NixOS module list:
+
+```nix
+dotfiles.nixosModules.unreal-storage
+```
+
+Importing the module alone has no runtime effect. Enable its mount contract
 explicitly:
 
 ```nix

--- a/docs/optional-tools.md
+++ b/docs/optional-tools.md
@@ -89,6 +89,8 @@ The initializer:
   accidental creation of a huge image on the root filesystem;
 - refuses to replace an existing image;
 - creates and formats only `/mnt/isotope/Unreal/unreal.ext4`;
+- rejects a requested logical size larger than the backing filesystem's current
+  available space;
 - temporarily loop-mounts the new ext4 filesystem to establish user ownership
   and the `Engine`, `Projects`, and `Toolchains` directories;
 - removes a newly created image if initialization fails before completion;
@@ -98,7 +100,9 @@ The initializer:
 `500G` is only an example. Choose the logical upper bound appropriate for the
 isotope drive. With backing-filesystem sparse-file support, physical allocation
 can grow as ext4 data is written rather than consuming the complete logical size
-immediately.
+immediately. A sparse image is not a capacity boundary for the backing drive:
+keep free-space headroom on `/mnt/isotope` and monitor it so the host filesystem
+cannot fill while ext4 still believes it has writable blocks.
 
 The Dubnium Home Manager profile selects:
 

--- a/docs/optional-tools.md
+++ b/docs/optional-tools.md
@@ -43,11 +43,83 @@ dotfiles.unreal = {
 
 Prefer a native Linux filesystem for `engineRoot`. A Linux Unreal installation
 contains executable toolchains and expects normal POSIX path, permission,
-symlink, and case semantics. Do not make NTFS, exFAT, VFAT, CIFS, or another
-non-POSIX filesystem the default without validating the actual mount semantics.
+symlink, and case semantics. Direct NTFS/exFAT/VFAT/CIFS engine and build trees
+should therefore be treated as compatibility configurations rather than the
+portable default.
 
-The installer refuses to replace an existing engine and validates that the
-archive contains `Engine/Binaries/Linux/UnrealEditor` before publishing the
+### Dubnium isotope-backed storage
+
+Dubnium can keep the large engine, projects, and toolchains physically on the
+`/mnt/isotope` drive while exposing them to Unreal through a native ext4
+filesystem image:
+
+```text
+/mnt/isotope/Unreal/unreal.ext4
+             |
+             | loop-mounted ext4
+             v
+/srv/unreal/
+├── Engine/
+├── Projects/
+└── Toolchains/
+```
+
+The NixOS storage support is also disabled by default. Enable its mount contract
+explicitly:
+
+```nix
+dubnium.unreal.storage.enable = true;
+```
+
+Enabling the module does **not** create or format an image. It adds the guarded
+`unreal-storage-init` helper and an ext4 loop mount at `/srv/unreal` using
+`loop,noatime,nofail,x-systemd.automount`. The mount declares `/mnt/isotope` as a
+dependency when that filesystem is managed by NixOS.
+
+After switching to the configuration, explicitly create an image of the desired
+logical capacity:
+
+```bash
+sudo unreal-storage-init 500G
+```
+
+The initializer:
+
+- refuses to run unless `/mnt/isotope` is an actual mounted filesystem, avoiding
+  accidental creation of a huge image on the root filesystem;
+- refuses to replace an existing image;
+- creates and formats only `/mnt/isotope/Unreal/unreal.ext4`;
+- temporarily loop-mounts the new ext4 filesystem to establish user ownership
+  and the `Engine`, `Projects`, and `Toolchains` directories;
+- removes a newly created image if initialization fails before completion;
+- warns when the backing filesystem is `ntfs3` without its `sparse` mount option;
+- reports the image's actual allocated size with `du` after initialization.
+
+`500G` is only an example. Choose the logical upper bound appropriate for the
+isotope drive. With backing-filesystem sparse-file support, physical allocation
+can grow as ext4 data is written rather than consuming the complete logical size
+immediately.
+
+The Dubnium Home Manager profile selects:
+
+```nix
+dotfiles.unreal.engineRoot = "/srv/unreal/Engine/5.8";
+```
+
+but does not enable either Unreal or its storage. This keeps the normal machine
+configuration unchanged until both features are deliberately selected.
+
+Keep the hot Zen/DDC cache on native system storage by default:
+
+```text
+$XDG_CACHE_HOME/unreal-engine/zen
+```
+
+The authenticated Epic ZIP and other inert downloads can live directly under
+`/mnt/isotope/Unreal/` without requiring POSIX execution semantics.
+
+The Unreal installer refuses to replace an existing engine and validates that
+the archive contains `Engine/Binaries/Linux/UnrealEditor` before publishing the
 staged directory.
 
 Launch the editor from the desktop entry or with:
@@ -62,8 +134,7 @@ engine payload or Steam client part of the system closure.
 
 Epic's Installed Build deployment model is intentionally compatible with a
 read-only engine distribution. The wrapper therefore keeps Zen/DDC mutation in
-a separate writable cache root, defaulting to
-`$XDG_CACHE_HOME/unreal-engine/zen`. The engine directory can be treated as
+a separate writable cache root. The engine directory can be treated as
 immutable after installation as long as workflows that intentionally modify the
 engine are handled separately.
 

--- a/docs/optional-tools.md
+++ b/docs/optional-tools.md
@@ -30,15 +30,18 @@ Linux installed-build ZIP from Epic and install it with:
 unreal-install ~/Downloads/Linux_Unreal_Engine_5.8.zip
 ```
 
-By default the archive is extracted to `$XDG_DATA_HOME/unreal-engine`. The helper
-refuses to replace an existing installation and validates that the archive
-contains `Engine/Binaries/Linux/UnrealEditor` before publishing the directory.
-To keep multiple versions, choose a distinct root in local Home Manager config:
+The portable module default is `$XDG_DATA_HOME/unreal-engine`. The Dubnium
+profile overrides only the destination to `/mnt/isotope/Unreal/5.8` so the large
+mutable engine tree stays off the root filesystem; it does not enable Unreal.
+The helper refuses to replace an existing installation and validates that the
+archive contains `Engine/Binaries/Linux/UnrealEditor` before publishing the
+directory. To keep multiple versions on another profile, choose a distinct root
+in local Home Manager config:
 
 ```nix
 dotfiles.unreal = {
   enable = true;
-  engineRoot = "/mnt/isotope/Unreal/5.8";
+  engineRoot = "/path/to/Unreal/5.8";
 };
 ```
 
@@ -48,10 +51,10 @@ Launch the editor from the desktop entry or with:
 unreal-editor
 ```
 
-The launcher exports `UE_ROOT` and runs the external Epic binary through
-`steam-run`, providing an FHS-compatible runtime for NixOS without making the
-engine payload part of the system closure. Project files and engine-generated
-state remain normal mutable user data.
+The launcher exports `UE_ROOT` and runs the external Epic binary through the
+free `steam-run` FHS runtime, providing NixOS compatibility without making the
+engine payload or Steam client part of the system closure. Project files and
+engine-generated state remain normal mutable user data.
 
 ## OpenWork
 

--- a/flake.nix
+++ b/flake.nix
@@ -324,7 +324,7 @@
               # Install custom pre-push hook (WIP, tag, submodule checks)
               mkdir -p "$git_hook_dir"
               cp -f ${prePushHook}/bin/pre-push-hook "$git_hook_dir/pre-push"
-              chmod +x ${prePushHook}/bin/pre-push-hook "$git_hook_dir/pre-push"
+              chmod +x "$git_hook_dir/pre-push"
             fi
           '';
           buildInputs = enabledPackages;

--- a/flake.nix
+++ b/flake.nix
@@ -359,6 +359,8 @@
       homeConfigurations."${username}@meeting-verify" = mkHomeConfig ./home/ryjen/meeting-verify-home.nix;
       homeConfigurations."${username}@unreal-verify" = mkHomeConfig ./home/ryjen/unreal-verify-home.nix;
 
+      nixosModules.unreal-storage = ./modules/nixos/unreal-storage.nix;
+
       nixosModules.dubnium-home-manager =
         {
           config,

--- a/flake.nix
+++ b/flake.nix
@@ -74,6 +74,7 @@
         };
       mkNixosConfig =
         profileModule:
+        extraModules:
         nixpkgs.lib.nixosSystem {
           inherit system;
           specialArgs = {
@@ -110,7 +111,8 @@
                 ];
               };
             }
-          ];
+          ]
+          ++ extraModules;
         };
     in
     {
@@ -322,7 +324,7 @@
               # Install custom pre-push hook (WIP, tag, submodule checks)
               mkdir -p "$git_hook_dir"
               cp -f ${prePushHook}/bin/pre-push-hook "$git_hook_dir/pre-push"
-              chmod +x "$git_hook_dir/pre-push"
+              chmod +x ${prePushHook}/bin/pre-push-hook "$git_hook_dir/pre-push"
             fi
           '';
           buildInputs = enabledPackages;
@@ -334,8 +336,19 @@
         openwork = pkgs.callPackage ./packages/openwork.nix { };
       };
 
-      nixosConfigurations.nixos = mkNixosConfig ./home/ryjen/home.nix;
-      nixosConfigurations.verify = mkNixosConfig ./home/ryjen/verify-home.nix;
+      nixosConfigurations.nixos = mkNixosConfig ./home/ryjen/home.nix [ ];
+      nixosConfigurations.verify = mkNixosConfig ./home/ryjen/verify-home.nix [
+        {
+          # CI-only evaluation of the optional loop-storage contract. Building
+          # this configuration never creates or mounts the image.
+          dubnium.unreal.storage = {
+            enable = true;
+            backingMount = "/tmp";
+            imagePath = "/tmp/unreal-storage-verify.ext4";
+            mountPoint = "/srv/unreal-verify";
+          };
+        }
+      ];
 
       homeConfigurations."${username}@nixos" = mkHomeConfig ./home/ryjen/home.nix;
       homeConfigurations."${username}@verify" = mkHomeConfig ./home/ryjen/verify-home.nix;

--- a/flake.nix
+++ b/flake.nix
@@ -344,6 +344,7 @@
       homeConfigurations."${username}@dubnium" = mkHomeConfig ./home/ryjen/dubnium-home.nix;
       homeConfigurations."${username}@technetium" = mkHomeConfig ./home/ryjen/technetium-home.nix;
       homeConfigurations."${username}@meeting-verify" = mkHomeConfig ./home/ryjen/meeting-verify-home.nix;
+      homeConfigurations."${username}@unreal-verify" = mkHomeConfig ./home/ryjen/unreal-verify-home.nix;
 
       nixosModules.dubnium-home-manager =
         {

--- a/home/ryjen/profiles/dubnium.nix
+++ b/home/ryjen/profiles/dubnium.nix
@@ -14,10 +14,6 @@
   dotfiles.opsCadence.enable = lib.mkDefault true;
   dotfiles.hypr.adoptedProfile = "dubnium";
 
-  # Keep the large mutable Unreal installed build off the root filesystem while
-  # leaving the editor support itself opt-in.
-  dotfiles.unreal.engineRoot = lib.mkDefault "/mnt/isotope/Unreal/5.8";
-
   dotfiles.bitwarden.cli.enable = lib.mkDefault true;
   dotfiles.bitwarden.desktop.enable = lib.mkDefault false;
 

--- a/home/ryjen/profiles/dubnium.nix
+++ b/home/ryjen/profiles/dubnium.nix
@@ -14,6 +14,10 @@
   dotfiles.opsCadence.enable = lib.mkDefault true;
   dotfiles.hypr.adoptedProfile = "dubnium";
 
+  # Keep the large mutable Unreal installed build off the root filesystem while
+  # leaving the editor support itself opt-in.
+  dotfiles.unreal.engineRoot = lib.mkDefault "/mnt/isotope/Unreal/5.8";
+
   dotfiles.bitwarden.cli.enable = lib.mkDefault true;
   dotfiles.bitwarden.desktop.enable = lib.mkDefault false;
 

--- a/home/ryjen/profiles/dubnium.nix
+++ b/home/ryjen/profiles/dubnium.nix
@@ -14,6 +14,11 @@
   dotfiles.opsCadence.enable = lib.mkDefault true;
   dotfiles.hypr.adoptedProfile = "dubnium";
 
+  # When Unreal is explicitly enabled, use the native Linux filesystem mounted
+  # from the optional isotope-backed storage image. This path selection alone
+  # does not enable Unreal or the storage module.
+  dotfiles.unreal.engineRoot = lib.mkDefault "/srv/unreal/Engine/5.8";
+
   dotfiles.bitwarden.cli.enable = lib.mkDefault true;
   dotfiles.bitwarden.desktop.enable = lib.mkDefault false;
 

--- a/home/ryjen/unreal-verify-home.nix
+++ b/home/ryjen/unreal-verify-home.nix
@@ -1,0 +1,23 @@
+{
+  username,
+  lib,
+  ...
+}:
+{
+  imports = [
+    ./layers/graphical.nix
+    ./profiles/verify.nix
+  ]
+  ++ lib.optional (builtins.pathExists ./user.local.nix) ./user.local.nix;
+
+  dotfiles.unreal = {
+    enable = true;
+    engineRoot = "/tmp/unreal-engine";
+    cacheRoot = "/tmp/unreal-cache";
+  };
+
+  home.username = username;
+  home.homeDirectory = "/home/${username}";
+  home.stateVersion = "25.05";
+  programs.home-manager.enable = true;
+}

--- a/home/ryjen/user.example.nix
+++ b/home/ryjen/user.example.nix
@@ -64,6 +64,11 @@
   # dotfiles.hypr.adoptedProfile = "empty";
   # dotfiles.waybar.variant = "workstation";
 
+  # Unreal Editor support remains disabled unless explicitly selected. The Epic
+  # installed-build payload stays outside the Nix store as mutable user data.
+  # dotfiles.unreal.enable = false;
+  # dotfiles.unreal.engineRoot = "${config.xdg.dataHome}/unreal-engine";
+
   # OpenWork desktop app and sandbox boundary.
   # dotfiles.openwork.enable = false;
   # dotfiles.openwork.sandbox.enable = true;

--- a/home/ryjen/user.example.nix
+++ b/home/ryjen/user.example.nix
@@ -64,10 +64,11 @@
   # dotfiles.hypr.adoptedProfile = "empty";
   # dotfiles.waybar.variant = "workstation";
 
-  # Unreal Editor support remains disabled unless explicitly selected. The Epic
-  # installed-build payload stays outside the Nix store as mutable user data.
+  # Unreal Editor support remains disabled unless explicitly selected. Keep the
+  # Epic installed build outside the Nix store and Zen/DDC in writable cache data.
   # dotfiles.unreal.enable = false;
   # dotfiles.unreal.engineRoot = "${config.xdg.dataHome}/unreal-engine";
+  # dotfiles.unreal.cacheRoot = "${config.xdg.cacheHome}/unreal-engine";
 
   # OpenWork desktop app and sandbox boundary.
   # dotfiles.openwork.enable = false;

--- a/hosts/nixos/configuration.nix
+++ b/hosts/nixos/configuration.nix
@@ -17,6 +17,15 @@
     appimage.enable = true;
     audio.enable = true;
     bluetooth.enable = true;
+
+    # CI-only evaluation of the optional loop-storage contract. The build never
+    # creates or mounts this image; it only proves the enabled NixOS module.
+    unreal.storage = {
+      enable = true;
+      backingMount = "/tmp";
+      imagePath = "/tmp/unreal-storage-verify.ext4";
+      mountPoint = "/srv/unreal-verify";
+    };
   };
 
   # This host is evaluated by CI as a generic NixOS verification target.

--- a/hosts/nixos/configuration.nix
+++ b/hosts/nixos/configuration.nix
@@ -17,15 +17,6 @@
     appimage.enable = true;
     audio.enable = true;
     bluetooth.enable = true;
-
-    # CI-only evaluation of the optional loop-storage contract. The build never
-    # creates or mounts this image; it only proves the enabled NixOS module.
-    unreal.storage = {
-      enable = true;
-      backingMount = "/tmp";
-      imagePath = "/tmp/unreal-storage-verify.ext4";
-      mountPoint = "/srv/unreal-verify";
-    };
   };
 
   # This host is evaluated by CI as a generic NixOS verification target.

--- a/modules/home/default.nix
+++ b/modules/home/default.nix
@@ -46,6 +46,7 @@
     ./starship.nix
     ./taskwarrior.nix
     ./tmux.nix
+    ./unreal.nix
     ./uv.nix
     ./vscode.nix
     ./waybar.nix

--- a/modules/home/unreal.nix
+++ b/modules/home/unreal.nix
@@ -78,7 +78,9 @@ let
     ];
     text = ''
       engine_root=${lib.escapeShellArg cfg.engineRoot}
+      cache_root=${lib.escapeShellArg cfg.cacheRoot}
       editor="$engine_root/Engine/Binaries/Linux/UnrealEditor"
+      zen_data="$cache_root/zen"
 
       if [[ ! -x "$editor" ]]; then
         echo "Unreal Editor is not installed at: $editor" >&2
@@ -87,8 +89,13 @@ let
         exit 127
       fi
 
+      mkdir -p -- "$zen_data"
       export UE_ROOT="$engine_root"
-      exec steam-run "$editor" "$@"
+
+      # Epic's Installed Build model supports a read-only engine distribution.
+      # Keep Zen/DDC mutation in an explicit user-writable cache location rather
+      # than relying on engine-relative cache state.
+      exec env "UE-ZenDataPath=$zen_data" steam-run "$editor" "$@"
     '';
   };
 in
@@ -99,8 +106,15 @@ in
     engineRoot = lib.mkOption {
       type = lib.types.str;
       default = "${config.xdg.dataHome}/unreal-engine";
-      example = "/mnt/isotope/Unreal/5.8";
-      description = "Mutable directory containing the extracted Unreal Engine Linux installed build";
+      example = "/data/unreal/5.8";
+      description = "Directory containing the extracted Unreal Engine Linux installed build";
+    };
+
+    cacheRoot = lib.mkOption {
+      type = lib.types.str;
+      default = "${config.xdg.cacheHome}/unreal-engine";
+      example = "/data/cache/unreal-engine";
+      description = "Writable cache root used for Unreal Zen/DDC state";
     };
   };
 
@@ -115,7 +129,18 @@ in
           cfg.engineRoot != "/"
           && cfg.engineRoot != "/nix/store"
           && !lib.hasPrefix "/nix/store/" cfg.engineRoot;
-        message = "dotfiles.unreal.engineRoot must be mutable storage outside / and /nix/store";
+        message = "dotfiles.unreal.engineRoot must live outside / and /nix/store";
+      }
+      {
+        assertion = lib.hasPrefix "/" cfg.cacheRoot;
+        message = "dotfiles.unreal.cacheRoot must be an absolute path";
+      }
+      {
+        assertion =
+          cfg.cacheRoot != "/"
+          && cfg.cacheRoot != "/nix/store"
+          && !lib.hasPrefix "/nix/store/" cfg.cacheRoot;
+        message = "dotfiles.unreal.cacheRoot must be writable storage outside / and /nix/store";
       }
     ];
 

--- a/modules/home/unreal.nix
+++ b/modules/home/unreal.nix
@@ -1,0 +1,123 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.dotfiles.unreal;
+
+  unrealInstaller = pkgs.writeShellApplication {
+    name = "unreal-install";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.unzip
+    ];
+    text = ''
+      if [[ $# -ne 1 ]]; then
+        echo "usage: unreal-install /path/to/Linux_Unreal_Engine.zip" >&2
+        exit 64
+      fi
+
+      archive="$(realpath -e -- "$1")"
+      engine_root=${lib.escapeShellArg cfg.engineRoot}
+      parent="$(dirname -- "$engine_root")"
+
+      if [[ -e "$engine_root" ]]; then
+        echo "Unreal Engine install already exists: $engine_root" >&2
+        echo "Choose a different dotfiles.unreal.engineRoot for another version." >&2
+        exit 73
+      fi
+
+      while IFS= read -r entry; do
+        case "$entry" in
+          /*|../*|*/../*|*/..)
+            echo "Refusing archive with unsafe path: $entry" >&2
+            exit 65
+            ;;
+        esac
+      done < <(unzip -Z1 -- "$archive")
+
+      mkdir -p -- "$parent"
+      staging="$(mktemp -d "$parent/.unreal-engine.XXXXXX")"
+      cleanup() {
+        rm -rf -- "$staging"
+      }
+      trap cleanup EXIT
+
+      unzip -q -- "$archive" -d "$staging"
+
+      editor="$staging/Engine/Binaries/Linux/UnrealEditor"
+      if [[ ! -f "$editor" ]]; then
+        echo "Archive does not contain Engine/Binaries/Linux/UnrealEditor at its root." >&2
+        echo "Expected an Epic Linux installed-build archive." >&2
+        exit 65
+      fi
+
+      chmod +x -- "$editor"
+      mv -- "$staging" "$engine_root"
+      trap - EXIT
+
+      echo "Installed Unreal Engine at $engine_root"
+      echo "Launch it with: unreal-editor"
+    '';
+  };
+
+  unrealEditor = pkgs.writeShellApplication {
+    name = "unreal-editor";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.steam-run
+    ];
+    text = ''
+      engine_root=${lib.escapeShellArg cfg.engineRoot}
+      editor="$engine_root/Engine/Binaries/Linux/UnrealEditor"
+
+      if [[ ! -x "$editor" ]]; then
+        echo "Unreal Editor is not installed at: $editor" >&2
+        echo "Download an Unreal Engine Linux installed-build ZIP from Epic, then run:" >&2
+        echo "  unreal-install /path/to/Linux_Unreal_Engine.zip" >&2
+        exit 127
+      fi
+
+      export UE_ROOT="$engine_root"
+      exec steam-run "$editor" "$@"
+    '';
+  };
+in
+{
+  options.dotfiles.unreal = {
+    enable = lib.mkEnableOption "Unreal Editor support";
+
+    engineRoot = lib.mkOption {
+      type = lib.types.str;
+      default = "${config.xdg.dataHome}/unreal-engine";
+      example = "/mnt/isotope/Unreal/5.8";
+      description = "Mutable directory containing the extracted Unreal Engine Linux installed build";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [
+      unrealEditor
+      unrealInstaller
+    ];
+
+    home.sessionVariables.UE_ROOT = cfg.engineRoot;
+
+    xdg.desktopEntries.unreal-editor = {
+      name = "Unreal Editor";
+      genericName = "Game engine editor";
+      comment = "Create and edit Unreal Engine projects";
+      exec = "unreal-editor %F";
+      icon = "applications-development";
+      terminal = false;
+      startupNotify = true;
+      categories = [
+        "Development"
+        "Graphics"
+        "3DGraphics"
+      ];
+    };
+  };
+}

--- a/modules/home/unreal.nix
+++ b/modules/home/unreal.nix
@@ -74,7 +74,7 @@ let
     name = "unreal-editor";
     runtimeInputs = [
       pkgs.coreutils
-      pkgs.steam-run
+      pkgs.steam.run-free
     ];
     text = ''
       engine_root=${lib.escapeShellArg cfg.engineRoot}

--- a/modules/home/unreal.nix
+++ b/modules/home/unreal.nix
@@ -23,11 +23,18 @@ let
       engine_root=${lib.escapeShellArg cfg.engineRoot}
       parent="$(dirname -- "$engine_root")"
 
+      if [[ ! -f "$archive" ]]; then
+        echo "Unreal Engine archive is not a regular file: $archive" >&2
+        exit 66
+      fi
+
       if [[ -e "$engine_root" ]]; then
         echo "Unreal Engine install already exists: $engine_root" >&2
         echo "Choose a different dotfiles.unreal.engineRoot for another version." >&2
         exit 73
       fi
+
+      unzip -tq -- "$archive" >/dev/null
 
       while IFS= read -r entry; do
         case "$entry" in
@@ -98,6 +105,20 @@ in
   };
 
   config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = lib.hasPrefix "/" cfg.engineRoot;
+        message = "dotfiles.unreal.engineRoot must be an absolute path";
+      }
+      {
+        assertion =
+          cfg.engineRoot != "/"
+          && cfg.engineRoot != "/nix/store"
+          && !lib.hasPrefix "/nix/store/" cfg.engineRoot;
+        message = "dotfiles.unreal.engineRoot must be mutable storage outside / and /nix/store";
+      }
+    ];
+
     home.packages = [
       unrealEditor
       unrealInstaller

--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -12,6 +12,7 @@
     ./podman.nix
     ./shell.nix
     ./syncthing.nix
+    ./unreal-storage.nix
   ];
 
   nix.settings.experimental-features = [

--- a/modules/nixos/unreal-storage.nix
+++ b/modules/nixos/unreal-storage.nix
@@ -60,30 +60,53 @@ let
         echo "the image will still work, but physical allocation may grow less efficiently" >&2
       fi
 
+      available_bytes="$(df --output=avail -B1 -- "$backing_mount" | tail -n 1 | tr -d ' ')"
+
       tmp_mount=""
       success=0
+      image_created=0
       cleanup() {
+        preserve_image=0
         if [[ -n "$tmp_mount" ]] && mountpoint -q -- "$tmp_mount"; then
-          umount -- "$tmp_mount" || true
+          if ! umount -- "$tmp_mount"; then
+            echo "warning: failed to unmount $tmp_mount; preserving $image" >&2
+            preserve_image=1
+          fi
         fi
-        if [[ -n "$tmp_mount" ]]; then
+        if [[ -n "$tmp_mount" ]] && ! mountpoint -q -- "$tmp_mount"; then
           rmdir -- "$tmp_mount" 2>/dev/null || true
         fi
-        if [[ $success -ne 1 ]]; then
+        if [[ $success -ne 1 && $image_created -eq 1 && $preserve_image -eq 0 ]]; then
           rm -f -- "$image"
         fi
       }
       trap cleanup EXIT
 
-      install -d -m 0755 -- "$(dirname -- "$image")"
-      truncate -s "$size" -- "$image"
+      image_parent="$(dirname -- "$image")"
+      install -d -m 0755 -- "$image_parent"
+
+      resolved_backing="$(realpath -e -- "$backing_mount")"
+      resolved_parent="$(realpath -e -- "$image_parent")"
+      case "$resolved_parent" in
+        "$resolved_backing"|"$resolved_backing"/*) ;;
+        *)
+          echo "Resolved image parent escapes backing mount: $resolved_parent" >&2
+          exit 78
+          ;;
+      esac
+
+      if ! (set -o noclobber; : > "$image") 2>/dev/null; then
+        echo "Refusing to replace an image path created concurrently: $image" >&2
+        exit 73
+      fi
+      image_created=1
       chmod 0600 -- "$image"
+      truncate -s "$size" -- "$image"
 
       logical_bytes="$(stat -c %s -- "$image")"
-      available_bytes="$(df --output=avail -B1 -- "$backing_mount" | tail -n 1 | tr -d ' ')"
       if (( logical_bytes > available_bytes )); then
-        echo "Requested logical image size exceeds current free space on $backing_mount." >&2
-        echo "requested: $logical_bytes bytes; available: $available_bytes bytes" >&2
+        echo "Requested logical image size exceeds free space on $backing_mount." >&2
+        echo "requested: $logical_bytes bytes; pre-creation available: $available_bytes bytes" >&2
         exit 75
       fi
 

--- a/modules/nixos/unreal-storage.nix
+++ b/modules/nixos/unreal-storage.nix
@@ -1,0 +1,173 @@
+{
+  config,
+  lib,
+  pkgs,
+  username,
+  ...
+}:
+let
+  cfg = config.dubnium.unreal.storage;
+
+  storageInit = pkgs.writeShellApplication {
+    name = "unreal-storage-init";
+    runtimeInputs = [
+      pkgs.coreutils
+      pkgs.e2fsprogs
+      pkgs.util-linux
+    ];
+    text = ''
+      if [[ $EUID -ne 0 ]]; then
+        echo "unreal-storage-init must run as root (use sudo)." >&2
+        exit 77
+      fi
+
+      if [[ $# -ne 1 || -z "$1" || "$1" == -* ]]; then
+        echo "usage: sudo unreal-storage-init SIZE" >&2
+        echo "example: sudo unreal-storage-init 500G" >&2
+        exit 64
+      fi
+
+      size="$1"
+      backing_mount=${lib.escapeShellArg cfg.backingMount}
+      image=${lib.escapeShellArg cfg.imagePath}
+      owner=${lib.escapeShellArg cfg.owner}
+      group=${lib.escapeShellArg cfg.group}
+
+      if ! mountpoint -q -- "$backing_mount"; then
+        echo "Backing storage is not mounted: $backing_mount" >&2
+        echo "Refusing to create the image on the root filesystem by accident." >&2
+        exit 69
+      fi
+
+      case "$image" in
+        "$backing_mount"/*) ;;
+        *)
+          echo "Image path is outside backing mount: $image" >&2
+          exit 78
+          ;;
+      esac
+
+      if [[ -e "$image" || -L "$image" ]]; then
+        echo "Unreal storage image already exists: $image" >&2
+        exit 73
+      fi
+
+      backing_fstype="$(findmnt -n -o FSTYPE --target "$backing_mount")"
+      backing_options="$(findmnt -n -o OPTIONS --target "$backing_mount")"
+      if [[ "$backing_fstype" == "ntfs3" && ",$backing_options," != *,sparse,* ]]; then
+        echo "warning: $backing_mount uses ntfs3 without the sparse mount option" >&2
+        echo "the image will still work, but physical allocation may grow less efficiently" >&2
+      fi
+
+      install -d -m 0755 -- "$(dirname -- "$image")"
+      truncate -s "$size" -- "$image"
+      chmod 0600 -- "$image"
+
+      tmp_mount="$(mktemp -d /run/unreal-storage-init.XXXXXX)"
+      success=0
+      cleanup() {
+        if mountpoint -q -- "$tmp_mount"; then
+          umount -- "$tmp_mount" || true
+        fi
+        rmdir -- "$tmp_mount" 2>/dev/null || true
+        if [[ $success -ne 1 ]]; then
+          rm -f -- "$image"
+        fi
+      }
+      trap cleanup EXIT
+
+      mkfs.ext4 -F -L unreal-store "$image"
+      mount -o loop,noatime "$image" "$tmp_mount"
+
+      chown "$owner:$group" "$tmp_mount"
+      chmod 0755 "$tmp_mount"
+      install -d -m 0755 -o "$owner" -g "$group" \
+        "$tmp_mount/Engine" \
+        "$tmp_mount/Projects" \
+        "$tmp_mount/Toolchains"
+
+      sync -f "$tmp_mount"
+      umount -- "$tmp_mount"
+      success=1
+
+      echo "Created Unreal ext4 storage image: $image ($size logical size)"
+      echo "After the NixOS storage module is active, access it at: ${cfg.mountPoint}"
+      du -h -- "$image"
+    '';
+  };
+in
+{
+  options.dubnium.unreal.storage = {
+    enable = lib.mkEnableOption "loop-mounted native Linux storage for Unreal Engine data";
+
+    backingMount = lib.mkOption {
+      type = lib.types.str;
+      default = "/mnt/isotope";
+      description = "Existing mounted filesystem that stores the Unreal ext4 image";
+    };
+
+    imagePath = lib.mkOption {
+      type = lib.types.str;
+      default = "/mnt/isotope/Unreal/unreal.ext4";
+      description = "Path to the pre-created ext4 filesystem image used for Unreal storage";
+    };
+
+    mountPoint = lib.mkOption {
+      type = lib.types.str;
+      default = "/srv/unreal";
+      description = "Native Linux mount point exposed to Unreal Engine and its toolchains";
+    };
+
+    owner = lib.mkOption {
+      type = lib.types.str;
+      default = username;
+      description = "User that owns the root and initial directories created in a new image";
+    };
+
+    group = lib.mkOption {
+      type = lib.types.str;
+      default = "users";
+      description = "Group that owns the root and initial directories created in a new image";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    assertions = [
+      {
+        assertion = lib.hasPrefix "/" cfg.backingMount && cfg.backingMount != "/";
+        message = "dubnium.unreal.storage.backingMount must be an absolute non-root mount point";
+      }
+      {
+        assertion =
+          lib.hasPrefix "${cfg.backingMount}/" cfg.imagePath
+          && cfg.imagePath != cfg.backingMount;
+        message = "dubnium.unreal.storage.imagePath must be beneath backingMount";
+      }
+      {
+        assertion =
+          lib.hasPrefix "/" cfg.mountPoint
+          && cfg.mountPoint != "/"
+          && cfg.mountPoint != "/nix"
+          && cfg.mountPoint != "/nix/store"
+          && !lib.hasPrefix "/nix/store/" cfg.mountPoint
+          && !lib.hasPrefix "${cfg.backingMount}/" cfg.mountPoint;
+        message = "dubnium.unreal.storage.mountPoint must be a safe absolute path outside backingMount and /nix";
+      }
+    ];
+
+    environment.systemPackages = [ storageInit ];
+
+    fileSystems.${cfg.mountPoint} = {
+      device = cfg.imagePath;
+      fsType = "ext4";
+      depends = [ cfg.backingMount ];
+      options = [
+        "loop"
+        "noatime"
+        "nofail"
+        "x-systemd.automount"
+        "x-systemd.idle-timeout=15min"
+      ];
+    };
+  };
+}

--- a/modules/nixos/unreal-storage.nix
+++ b/modules/nixos/unreal-storage.nix
@@ -2,7 +2,7 @@
   config,
   lib,
   pkgs,
-  username,
+  username ? "ryjen",
   ...
 }:
 let
@@ -155,7 +155,7 @@ in
 
     owner = lib.mkOption {
       type = lib.types.str;
-      default = username;
+      default = lib.attrByPath [ "dubnium" "user" "name" ] username config;
       description = "User that owns the root and initial directories created in a new image";
     };
 

--- a/modules/nixos/unreal-storage.nix
+++ b/modules/nixos/unreal-storage.nix
@@ -112,7 +112,7 @@ let
 
       tmp_mount="$(mktemp -d /run/unreal-storage-init.XXXXXX)"
       mkfs.ext4 -F -L unreal-store "$image"
-      mount -o loop,noatime "$image" "$tmp_mount"
+      mount -o loop,noatime,nodev,nosuid "$image" "$tmp_mount"
 
       chown "$owner:$group" "$tmp_mount"
       chmod 0755 "$tmp_mount"
@@ -199,6 +199,8 @@ in
       options = [
         "loop"
         "noatime"
+        "nodev"
+        "nosuid"
         "nofail"
         "x-systemd.automount"
         "x-systemd.idle-timeout=15min"

--- a/modules/nixos/unreal-storage.nix
+++ b/modules/nixos/unreal-storage.nix
@@ -21,8 +21,9 @@ let
         exit 77
       fi
 
-      if [[ $# -ne 1 || -z "$1" || "$1" == -* ]]; then
+      if [[ $# -ne 1 || ! "$1" =~ ^[1-9][0-9]*[KMGT]$ ]]; then
         echo "usage: sudo unreal-storage-init SIZE" >&2
+        echo "SIZE must be an integer followed by K, M, G, or T." >&2
         echo "example: sudo unreal-storage-init 500G" >&2
         exit 64
       fi
@@ -59,23 +60,34 @@ let
         echo "the image will still work, but physical allocation may grow less efficiently" >&2
       fi
 
-      install -d -m 0755 -- "$(dirname -- "$image")"
-      truncate -s "$size" -- "$image"
-      chmod 0600 -- "$image"
-
-      tmp_mount="$(mktemp -d /run/unreal-storage-init.XXXXXX)"
+      tmp_mount=""
       success=0
       cleanup() {
-        if mountpoint -q -- "$tmp_mount"; then
+        if [[ -n "$tmp_mount" ]] && mountpoint -q -- "$tmp_mount"; then
           umount -- "$tmp_mount" || true
         fi
-        rmdir -- "$tmp_mount" 2>/dev/null || true
+        if [[ -n "$tmp_mount" ]]; then
+          rmdir -- "$tmp_mount" 2>/dev/null || true
+        fi
         if [[ $success -ne 1 ]]; then
           rm -f -- "$image"
         fi
       }
       trap cleanup EXIT
 
+      install -d -m 0755 -- "$(dirname -- "$image")"
+      truncate -s "$size" -- "$image"
+      chmod 0600 -- "$image"
+
+      logical_bytes="$(stat -c %s -- "$image")"
+      available_bytes="$(df --output=avail -B1 -- "$backing_mount" | tail -n 1 | tr -d ' ')"
+      if (( logical_bytes > available_bytes )); then
+        echo "Requested logical image size exceeds current free space on $backing_mount." >&2
+        echo "requested: $logical_bytes bytes; available: $available_bytes bytes" >&2
+        exit 75
+      fi
+
+      tmp_mount="$(mktemp -d /run/unreal-storage-init.XXXXXX)"
       mkfs.ext4 -F -L unreal-store "$image"
       mount -o loop,noatime "$image" "$tmp_mount"
 


### PR DESCRIPTION
## What changed

- add an optional `dotfiles.unreal` Home Manager module, disabled by default
- add `unreal-install` for non-destructive installation of an authenticated Epic Linux installed-build ZIP outside the Nix store
- add `unreal-editor`, which launches the external engine through Nixpkgs' free `steam-run` FHS runtime
- export `UE_ROOT`, keep Zen/DDC under a separate writable cache root, and add an Unreal Editor desktop entry when enabled
- add an `unreal-verify` Home Manager output and build it in CI with `enable = true`
- add optional NixOS `dubnium.unreal.storage` support for a native ext4 image physically stored on `/mnt/isotope`
- export that storage contract as `nixosModules.unreal-storage` for external NixOS compositions such as Dubnium
- default Dubnium's engine path to `/srv/unreal/Engine/5.8` without enabling either Unreal or its storage
- document read-only Installed Build behavior, project/plugin write boundaries, Linux C++ toolchain requirements, Fab limitations, and isotope-backed storage

## Storage design

The large Unreal payload can live on the isotope NTFS drive without exposing NTFS semantics to the Linux engine/toolchain:

```text
/mnt/isotope/Unreal/unreal.ext4
             |
             | loop-mounted ext4
             v
/srv/unreal/
├── Engine/
├── Projects/
└── Toolchains/
```

`dubnium.unreal.storage.enable` uses `mkEnableOption`, so this storage support is also disabled by default. Enabling it adds only the guarded initializer and a `loop,noatime,nodev,nosuid,nofail,x-systemd.automount` ext4 mount; NixOS activation never creates or formats the image.

Image creation is an explicit privileged action such as:

```bash
sudo unreal-storage-init 500G
```

The initializer refuses to run unless the configured backing mount is actually mounted, never replaces an existing image, removes a newly-created image on initialization failure only after it is safely unmounted, establishes user ownership and `Engine`/`Projects`/`Toolchains`, warns about NTFS3 sparse-file configuration, and rejects logical image sizes larger than the backing filesystem's pre-creation free space.

## Why

Epic's Installed Build model supports a standalone read-only engine distribution. Keeping the authenticated Epic payload outside `/nix/store` while presenting a native ext4 filesystem allows the engine, projects, and Linux toolchains to use normal POSIX semantics even though the physical bytes are on the large isotope NTFS volume. Writable Zen/DDC remains on native system storage by default.

## Default behavior

`dotfiles.unreal.enable` and `dubnium.unreal.storage.enable` both default to `false`. No Unreal launcher, installer helper, desktop entry, FHS runtime, storage initializer, loop mount, or engine payload is active unless explicitly enabled. Importing `dotfiles.nixosModules.unreal-storage` alone is a no-op; the Dubnium Home Manager profile only selects the future engine path.

## Safety

- engine installation is staged under the destination filesystem and published only after archive/layout validation
- existing engine roots and storage images are never replaced
- storage initialization refuses to proceed when the backing mount is absent, avoiding accidental creation under `/mnt/isotope` on the root filesystem
- requested image logical size is checked against free backing space captured before file creation, so eager-allocation filesystems do not produce a false rejection
- image creation uses a no-clobber step and validates the resolved image parent remains beneath the resolved backing mount
- failed initialization removes only the image created by that invocation and preserves it if emergency unmount fails
- storage mount is `nodev,nosuid,nofail` and automounted rather than boot-critical
- NixOS `fileSystems.depends` ties the loop filesystem to the configured backing path
- engine/cache/storage paths are kept outside `/` and `/nix/store`
- Epic credentials/downloads remain outside Nix and dotfiles
- Zen/DDC data is redirected to writable cache state via `UE-ZenDataPath`

## Limitations

- a sparse ext4 image still depends on physical free space remaining on the backing drive; the isotope volume must retain headroom over time
- Unreal projects themselves must be writable for content/config changes and generated `Saved`, `Intermediate`, `Binaries`, cooking, autosave, and log state
- engine-level plugin installation mutates `Engine/Plugins`; project-local plugins under `<Project>/Plugins` avoid that immutable-engine conflict
- C++ development requires Epic's supported Linux clang/native toolchain setup in addition to this editor integration
- Fab's launcher-based `Install to Engine` workflow is less directly applicable on Linux than project-local content/plugin workflows
- engine updates are deliberate side-by-side/manual installs rather than Epic Launcher in-place updates
- NixOS is outside Epic's documented recommended Linux distro set; `steam-run` is a compatibility boundary and the authenticated Epic editor binary still needs a real workstation smoke test

## Validation

- reviewed against Epic's Unreal Engine Installed Build, directory structure, DDC/Zen, plugin, Fab, and Linux toolchain documentation
- reviewed against NixOS `fileSystems` loop-mount behavior and dependency support
- Linux kernel NTFS3 documentation confirms read/write sparse-file support; the initializer reports/warns rather than assuming the backing mount options
- CI builds the enabled `unreal-verify` Home Manager activation, realizing the wrappers and `steam.run-free`
- only `nixosConfigurations.verify` enables `dubnium.unreal.storage` against dummy paths, so CI builds the enabled storage module without leaking a dummy mount into the normal NixOS output
- the storage module is exported as `dotfiles.nixosModules.unreal-storage` and resolves the configured Dubnium user when embedded in that host composition
- User option catalog and Ops Cadence checks are passing; Nix CI is the final declarative gate
- actual Unreal Editor runtime is not exercised in CI because the Epic payload is authenticated/proprietary

## Migration

None. A consuming NixOS host first imports `dotfiles.nixosModules.unreal-storage`. To use the isotope-backed layout, explicitly enable `dubnium.unreal.storage`, switch the NixOS configuration, initialize the desired image size, then enable `dotfiles.unreal` and install the authenticated Epic ZIP.