### PR TITLE
Use monospace Waybar tooltips

### DIFF
--- a/files/home/.config/waybar/style.css
+++ b/files/home/.config/waybar/style.css
@@ -12,6 +12,10 @@ window#waybar {
     transition-duration: .5s;
 }
 
+tooltip label {
+    font-family: "JetBrainsMono Nerd Font Mono", "JetBrainsMono Nerd Font", "Symbols Nerd Font Mono", "monospace";
+}
+
 #workspaces {
     background: rgba(0, 0, 0, 0.3);
     margin: 4px;


### PR DESCRIPTION
## What changed
- render Waybar tooltip labels with the same JetBrains Mono stack used by the bar

## Why
GTK tooltips are separate widgets and do not reliably inherit `window#waybar` font settings. The disk tooltip uses fixed-width `printf` columns, so a proportional tooltip font breaks alignment. GTK/Pango tooltip markup does not provide table-style fixed column widths, making a monospace tooltip the reliable layout.

## Impact
- disk hover columns align correctly
- other Waybar tooltips also use the bar's monospace typography for consistency
- no disk metric or sampling behavior changes

## Validation
- CSS-only change scoped to `tooltip label`
- Nix CI will validate the branch