### PR TITLE
ci: cancel superseded workflow runs

### DIFF
--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -10,8 +10,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   discover-checks:

--- a/.github/workflows/user-option-catalog.yml
+++ b/.github/workflows/user-option-catalog.yml
@@ -23,7 +23,7 @@ permissions:
 
 concurrency:
   group: user-option-catalog-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: true
 
 jobs:
   verify:


### PR DESCRIPTION
## Summary

Cancel obsolete CI work when a newer commit arrives on the same pull request or protected branch.

- make `Nix CI` concurrency ref-scoped with `cancel-in-progress: true`;
- make `User option catalog` cancel superseded push runs as well as PR runs;
- preserve the already-correct `Ops Cadence Module` behavior.

This reduces redundant runner occupancy without changing job commands, permissions, or runner selection.

Related cross-repo audit: `ryjen/dubnium`, `hackelia-micrantha/hyperion`, and `hackelia-micrantha/dubnium-community`.