### PR TITLE
Use prefix-aware Zsh history navigation

### DIFF
--- a/modules/home/zsh.nix
+++ b/modules/home/zsh.nix
@@ -14,7 +14,6 @@
     enableCompletion = true;
     autosuggestion.enable = true;
     syntaxHighlighting.enable = true;
-    historySubstringSearch.enable = true;
 
     history = {
       size = 100000;
@@ -57,8 +56,16 @@
       autoload -U down-line-or-beginning-search
       zle -N up-line-or-beginning-search
       zle -N down-line-or-beginning-search
-      bindkey "^[[A" up-line-or-beginning-search
-      bindkey "^[[B" down-line-or-beginning-search
+      zmodload zsh/terminfo
+
+      # Prefix-aware history navigation. Bind both common cursor encodings plus
+      # the terminal-advertised sequence so arrows work in normal/application mode.
+      for key in "^[[A" "^[OA" "''${terminfo[kcuu1]}"; do
+        [[ -n "$key" ]] && bindkey "$key" up-line-or-beginning-search
+      done
+      for key in "^[[B" "^[OB" "''${terminfo[kcud1]}"; do
+        [[ -n "$key" ]] && bindkey "$key" down-line-or-beginning-search
+      done
 
       # extra variables
       export GPG_TTY=$(tty)


### PR DESCRIPTION
## Summary

- use native Zsh `up-line-or-beginning-search` / `down-line-or-beginning-search` for arrow-key history navigation
- remove `zsh-history-substring-search`, which Home Manager sourced later and used to override the native arrow bindings
- bind both common cursor encodings plus the terminal-advertised `terminfo` sequences for normal/application cursor modes

## Behavior

Typing a prefix such as:

```text
ls -a
```

then pressing Up/Down cycles through history entries beginning with that prefix rather than unrelated commands.

## Validation

- compared branch against `main`: one commit, one modified file (`modules/home/zsh.nix`)
- verified the generated branch content and Nix interpolation escaping for the `terminfo` parameters
- local Nix/Zsh execution was not available in this session, so runtime validation should come from repository checks and/or `dubctl apply` on the host
